### PR TITLE
Remove scaffolding for phoenix live views

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,7 @@ config :prtl, PrtlWeb.Endpoint,
   url: [host: "localhost"],
   render_errors: [view: PrtlWeb.ErrorView, accepts: ~w(html json), layout: false],
   pubsub_server: Prtl.PubSub,
+  # Required for LiveDashboard
   live_view: [signing_salt: "ZgDeMeHP"]
 
 # Configures the mailer

--- a/lib/prtl_web.ex
+++ b/lib/prtl_web.ex
@@ -42,38 +42,12 @@ defmodule PrtlWeb do
     end
   end
 
-  def live_view do
-    quote do
-      use Phoenix.LiveView,
-        layout: {PrtlWeb.LayoutView, "live.html"}
-
-      unquote(view_helpers())
-    end
-  end
-
-  def live_component do
-    quote do
-      use Phoenix.LiveComponent
-
-      unquote(view_helpers())
-    end
-  end
-
-  def component do
-    quote do
-      use Phoenix.Component
-
-      unquote(view_helpers())
-    end
-  end
-
   def router do
     quote do
       use Phoenix.Router
 
       import Plug.Conn
       import Phoenix.Controller
-      import Phoenix.LiveView.Router
     end
   end
 
@@ -88,9 +62,6 @@ defmodule PrtlWeb do
     quote do
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML
-
-      # Import LiveView and .heex helpers (live_render, live_patch, <.form>, etc)
-      import Phoenix.LiveView.Helpers
 
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View

--- a/lib/prtl_web/endpoint.ex
+++ b/lib/prtl_web/endpoint.ex
@@ -10,6 +10,7 @@ defmodule PrtlWeb.Endpoint do
     signing_salt: "Ke6bG2r4"
   ]
 
+  # Required for LiveDashboard
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/prtl_web/router.ex
+++ b/lib/prtl_web/router.ex
@@ -4,7 +4,6 @@ defmodule PrtlWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
-    plug :fetch_live_flash
     plug :put_root_layout, {PrtlWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers

--- a/lib/prtl_web/templates/layout/live.html.heex
+++ b/lib/prtl_web/templates/layout/live.html.heex
@@ -1,3 +1,0 @@
-<main class="container">
-  <%= @inner_content %>
-</main>

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,6 @@ defmodule Prtl.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
-      {:phoenix_live_view, "~> 0.17.5"},
       {:floki, ">= 0.30.0", only: :test},
       {:phoenix_live_dashboard, "~> 0.6"},
       {:esbuild, "~> 0.3", runtime: Mix.env() == :dev},


### PR DESCRIPTION
Removes scaffolding code that was related to Phoenix.LiveView, since we are probably not going to use that feature. I've kept what's necessary for LiveDashboard though, since that might be useful for monitoring in production or local development.