### PR TITLE
Hacky to delete cookie off of myhub.net domain

### DIFF
--- a/lib/prtl_web/controllers/logout_controller.ex
+++ b/lib/prtl_web/controllers/logout_controller.ex
@@ -2,6 +2,10 @@ defmodule PrtlWeb.LogoutController do
   use PrtlWeb, :controller
 
   def index(conn, _) do
-    conn |> delete_resp_cookie(PrtlWeb.Plugs.Auth.get_cookie_name(), domain: ".#{ conn.host |> String.split(".") |> Enum.take(-2) |> Enum.join(".") }") |> redirect(to: "/")
+    conn
+    |> delete_resp_cookie(PrtlWeb.Plugs.Auth.get_cookie_name(),
+      domain: ".#{conn.host |> String.split(".") |> Enum.take(-2) |> Enum.join(".")}"
+    )
+    |> redirect(to: "/")
   end
 end


### PR DESCRIPTION
Test to try to fix logout route not deleting the cookie off of the deployed dev cluster.