### PR TITLE
Feature flag mechanism for backend and frontend

### DIFF
--- a/assets/src/components/display/HubForm.js
+++ b/assets/src/components/display/HubForm.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import "./HubForm.css";
 import { FormChoice } from "../common/FormChoice";
 import { formatNumber } from "../utils/formatNumber";
+import { featureIsEnabled, TIER_SELECTION, CCU_SELECTION, STORAGE_SELECTION } from "../utils/feature-flags";
 
 export function HubForm({ hub, setHub, isSubmitting, onSubmit }) {
   const onFormSubmit = (e) => {
@@ -31,34 +32,42 @@ export function HubForm({ hub, setHub, isSubmitting, onSubmit }) {
         <span className="domain">{hub.subdomain}.myhubs.net</span>
       </div>
 
-      <FormChoice
-        name="tier"
-        value={hub.tier}
-        choices={[{ value: "free" }, { value: "premium" }]}
-        onChange={(value) => setHub({ ...hub, tier: value })}
-      />
-
-      <FormChoice
-        name="ccu"
-        title="CCU"
-        value={hub.ccu_limit}
-        choices={[{ value: 25 }, { value: 50 }, { value: 100 }]}
-        allDisabled={isFreeTier}
-        onChange={(value) => setHub({ ...hub, ccu_limit: value })}
-      />
-
-      {!isFreeTier && choiceDisabled && (
-        <span className="warning">⚠️ You cannot choose storage options lower than your current usage.</span>
+      {featureIsEnabled(TIER_SELECTION) && (
+        <FormChoice
+          name="tier"
+          value={hub.tier}
+          choices={[{ value: "free" }, { value: "premium" }]}
+          onChange={(value) => setHub({ ...hub, tier: value })}
+        />
       )}
 
-      <FormChoice
-        name="storage"
-        title={`Storage (${formatNumber(hub.storage_usage_mb)} MB used)`}
-        value={hub.storage_limit_mb}
-        choices={storageChoices}
-        allDisabled={isFreeTier}
-        onChange={(value) => setHub({ ...hub, storage_limit_mb: value })}
-      />
+      {featureIsEnabled(CCU_SELECTION) && (
+        <FormChoice
+          name="ccu"
+          title="CCU"
+          value={hub.ccu_limit}
+          choices={[{ value: 25 }, { value: 50 }, { value: 100 }]}
+          allDisabled={isFreeTier}
+          onChange={(value) => setHub({ ...hub, ccu_limit: value })}
+        />
+      )}
+
+      {featureIsEnabled(STORAGE_SELECTION) && (
+        <>
+          {!isFreeTier && choiceDisabled && (
+            <span className="warning">⚠️ You cannot choose storage options lower than your current usage.</span>
+          )}
+
+          <FormChoice
+            name="storage"
+            title={`Storage (${formatNumber(hub.storage_usage_mb)} MB used)`}
+            value={hub.storage_limit_mb}
+            choices={storageChoices}
+            allDisabled={isFreeTier}
+            onChange={(value) => setHub({ ...hub, storage_limit_mb: value })}
+          />
+        </>
+      )}
 
       <button disabled={isSubmitting}>{isSubmitting ? "saving" : "save"}</button>
     </form>

--- a/assets/src/components/utils/feature-flags.js
+++ b/assets/src/components/utils/feature-flags.js
@@ -1,0 +1,14 @@
+/* global global */
+const NODE_ENV = typeof global !== "undefined" && global.process.env.NODE_ENV;
+const FEATURE_FLAGS = window.FEATURE_FLAGS || {};
+
+const TIER_SELECTION = "tierSelection";
+const CCU_SELECTION = "ccuSelection";
+const STORAGE_SELECTION = "storageSelection";
+
+function featureIsEnabled(flag) {
+  if (NODE_ENV === "test") return true;
+  return !!FEATURE_FLAGS[flag];
+}
+
+export { featureIsEnabled, TIER_SELECTION, CCU_SELECTION, STORAGE_SELECTION };

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,6 +34,13 @@ config :prtl, PrtlWeb.Plugs.Auth,
 
 config :prtl, Prtl.OrchClient, orch_host: "turkeyapi.local"
 
+config :prtl, Prtl.FeatureFlags,
+  create_hubs: true,
+  delete_hubs: true,
+  tier_selection: true,
+  ccu_selection: true,
+  storage_selection: true
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -54,3 +54,10 @@ config :prtl, PrtlWeb.Plugs.Auth,
     "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEA3RY0qLmdthY6Q0RZ4oyNQSL035BmYLNdleX1qVpG1zfQeLWf/otg\nc8Ho2w8y5wW2W5vpI4a0aexNV2evgfsZKtx0q5WWwjsr2xy0Ak1zhWTgZD+FoHVG\nJ0xeFse2PnEhrtWalLacTza5RKEJskbNiTTu4fD+UfOCMctlwudNSs+AkmiPSxc8\nnWrZ5BuvdnEXcJOuw0h4oyyUlkmj+Oa/ZQVH44lmPI9Ih0OakXWpIfOob3X0Xqcd\nywlMVI2hzBR3JNodRjyEz33p6E//lY4Iodw9NdcRpohGcxcgQ5vf4r4epLIacr0y\n5w1ZiRyf6BwyqJ6IBpA7yYpws3r9qxmAqwIDAQAB\n-----END RSA PUBLIC KEY-----\n"
 
 config :prtl, Prtl.OrchClient, orch_host: "turkeyapi:888"
+
+config :prtl, Prtl.FeatureFlags,
+  create_hubs: false,
+  delete_hubs: false,
+  tier_selection: false,
+  ccu_selection: false,
+  storage_selection: false

--- a/lib/prtl/feature_flags.ex
+++ b/lib/prtl/feature_flags.ex
@@ -1,0 +1,29 @@
+defmodule Prtl.FeatureFlags do
+  def enabled?(flag) when is_atom(flag) do
+    !!get_flags()[flag]
+  end
+
+  def actions_for_flags(always: always_enabled_actions, flags: flagged_actions) do
+    enabled_actions =
+      flagged_actions
+      |> Enum.filter(fn {flag, _action} -> enabled?(flag) end)
+      |> Enum.map(fn {_flag, action} -> action end)
+
+    [only: always_enabled_actions ++ enabled_actions]
+  end
+
+  def to_json() do
+    get_flags()
+    |> Enum.map(fn {flag, is_enabled} -> {flag |> to_string |> snake_to_camel, is_enabled} end)
+    |> Map.new()
+    |> Jason.encode!()
+  end
+
+  defp get_flags() do
+    Application.get_env(:prtl, Prtl.FeatureFlags)
+  end
+
+  defp snake_to_camel(str) do
+    str |> String.replace(~r/_./, fn s -> s |> String.slice(1, 1) |> String.upcase() end)
+  end
+end

--- a/lib/prtl_web/router.ex
+++ b/lib/prtl_web/router.ex
@@ -37,7 +37,18 @@ defmodule PrtlWeb.Router do
     pipe_through :jwt_authenticated
 
     resources("/account", Api.V1.AccountController, [:index])
-    resources("/hubs", Api.V1.HubController, [:index, :create, :delete])
+
+    resources(
+      "/hubs",
+      Api.V1.HubController,
+      Prtl.FeatureFlags.actions_for_flags(
+        always: [:index, :show],
+        flags: [
+          create_hubs: :create,
+          delete_hubs: :delete
+        ]
+      )
+    )
   end
 
   # Enables LiveDashboard only for development

--- a/lib/prtl_web/templates/page/index.html.heex
+++ b/lib/prtl_web/templates/page/index.html.heex
@@ -1,2 +1,5 @@
+<script type="text/javascript">
+  window.FEATURE_FLAGS = <%= raw Prtl.FeatureFlags.to_json() %>;
+</script>
 <script defer type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
 <div id="root"></div>


### PR DESCRIPTION
Adds a feature flag mechanism that can be configured in the backend and used in the frontend as well

- Adds helper utilities in `feature-flags.js` for using feature flags on the frontend
- Feature flags are passed to the frontend via JSON in the `index.html.heex` template
- Adds a `Prtl.FeatureFlags` module for utility functions, and checking feature flags on the backend
- Includes an `actions_for_flags` function that can be used to disable specified actions on a `resources` route
- All features are enabled in dev and test
- Disables hub creation, deletion, and tier, CCU, and storage selection in prod