### PR TITLE
Update tier to reflect latest requirements

### DIFF
--- a/assets/src/components/display/Hub.css
+++ b/assets/src/components/display/Hub.css
@@ -16,6 +16,8 @@
 }
 .hub > * {
   margin: 0.3em 0;
+  display: flex;
+  align-items: center;
 }
 .hub .hub-info {
   display: flex;
@@ -62,7 +64,7 @@
 .tag.free {
   background: #39e;
 }
-.tag.premium, .tag.mvp {
+.tag.mvp {
   background: #663df5;
 }
 .tag.creating,

--- a/assets/src/components/display/Hub.js
+++ b/assets/src/components/display/Hub.js
@@ -40,7 +40,7 @@ export function Hub({
       </span>
       <span className="hub-stats">
         <IconDrive />
-        {formatMegabytes(storage_usage_mb)}/ {formatMegabytes(storage_limit_mb)}
+        {formatMegabytes(storage_usage_mb)} / {formatMegabytes(storage_limit_mb)}
       </span>
 
       <div className="hub-buttons">

--- a/assets/src/components/display/HubForm.js
+++ b/assets/src/components/display/HubForm.js
@@ -14,7 +14,7 @@ export function HubForm({ hub, setHub, isSubmitting, onSubmit }) {
 
   const tierChoices = [
     { tier: "free", disabled: true, ccuLimit: 5, storageLimitMb: 250 },
-    { tier: "mvp", disabled: false, ccuLimit: 30, storageLimitMb: 2000 },
+    { tier: "mvp", disabled: false, ccuLimit: 25, storageLimitMb: 2000 },
   ];
 
   return (

--- a/assets/test/components/display/HubForm.test.js
+++ b/assets/test/components/display/HubForm.test.js
@@ -4,7 +4,7 @@ import { render } from "../../helpers/setup";
 import { HubForm } from "../../../src/components/display/HubForm";
 
 test("Hub form free tier is disabled", async () => {
-  const hub = { tier: "premium", ccu_limit: 10, storage_limit_mb: 10 };
+  const hub = { tier: "mvp", ccu_limit: 10, storage_limit_mb: 10 };
 
   const { findByRole } = render(<HubForm hub={hub} />);
 
@@ -13,10 +13,10 @@ test("Hub form free tier is disabled", async () => {
 });
 
 test("Hub form mvp tier is enabled", async () => {
-  const hub = { tier: "premium", ccu_limit: 10, storage_limit_mb: 10 };
+  const hub = { tier: "mvp", ccu_limit: 10, storage_limit_mb: 10 };
 
   const { findByRole } = render(<HubForm hub={hub} />);
 
-  const freeTier = await findByRole("radio", { name: "mvp 30 2GB" });
+  const freeTier = await findByRole("radio", { name: "mvp 25 2GB" });
   expect(freeTier.disabled).toBe(false);
 });

--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -18,7 +18,7 @@ defmodule Dash.Hub do
     field :status, Ecto.Enum, values: [:creating, :updating, :ready]
     field :storage_limit_mb, :integer
     field :subdomain, :string
-    field :tier, Ecto.Enum, values: [:free, :premium]
+    field :tier, Ecto.Enum, values: [:free, :mvp]
     belongs_to :account, Dash.Account, references: :account_id
 
     timestamps()
@@ -76,27 +76,27 @@ defmodule Dash.Hub do
 
   # Checks if account has at least one hub, if not, creates hub
   def ensure_default_hub(%Dash.Account{} = account, email) do
-    if !has_hubs(account), do: create_default_free_hub(account, email)
+    if !has_hubs(account), do: create_default_hub(account, email)
   end
 
-  @free_hub_defaults %{
-    tier: :free,
-    ccu_limit: 5,
-    storage_limit_mb: 100
+  @hub_defaults %{
+    tier: :mvp,
+    ccu_limit: 25,
+    storage_limit_mb: 2000
   }
 
-  def create_default_free_hub(%Dash.Account{} = account, fxa_email) do
+  def create_default_hub(%Dash.Account{} = account, fxa_email) do
     # TODO replace with request to orchestrator with email for a round trip to get this information.
-    free_subdomain_and_name = rand_string(10)
+    subdomain_and_name = rand_string(10)
 
     new_hub_params =
       %{
         instance_uuid: fake_uuid(),
-        name: free_subdomain_and_name,
-        subdomain: free_subdomain_and_name,
+        name: subdomain_and_name,
+        subdomain: subdomain_and_name,
         status: :creating
       }
-      |> Map.merge(@free_hub_defaults)
+      |> Map.merge(@hub_defaults)
 
     new_hub =
       %Dash.Hub{}

--- a/lib/dash_web/controllers/api/v1/hub_controller.ex
+++ b/lib/dash_web/controllers/api/v1/hub_controller.ex
@@ -24,11 +24,11 @@ defmodule DashWeb.Api.V1.HubController do
     conn |> render("index.json", hubs: hubs)
   end
 
-  # Create free hub with defaults
+  # Create hub with defaults
   def create(conn, _, account) do
     fxa_email = conn.assigns[:fxa_account_info].fxa_email
 
-    case Hub.create_default_free_hub(account, fxa_email) do
+    case Hub.create_default_hub(account, fxa_email) do
       {:ok, new_hub} -> conn |> render("create.json", hub: new_hub)
       {:error, err} -> conn |> send_resp(400, Jason.encode!(%{error: err})) |> halt()
     end


### PR DESCRIPTION
- Replaces "premium" tier with "mvp"
- Changes sets mvp tier limits to 25 CCU and 2GB storage
- Renamed functions and constants to avoid confusion with "free" tier
- Minor CSS and formatting changes