### PR TITLE
Add ability to update subdomain in the backend

### DIFF
--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -46,8 +46,13 @@ defmodule Dash.Hub do
 
   def form_changeset(hub, attrs) do
     hub
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :subdomain])
     |> validate_length(:name, min: 1, max: 24)
+    |> validate_length(:subdomain, min: 1, max: 63)
+    |> validate_format(:subdomain, ~r/^[a-z0-9]/i)
+    |> validate_format(:subdomain, ~r/^[a-z0-9-]+$/i)
+    |> validate_format(:subdomain, ~r/[a-z0-9]$/i)
+    |> unique_constraint(:subdomain)
   end
 
   defp hubs_for_account(%Dash.Account{} = account) do
@@ -77,12 +82,15 @@ defmodule Dash.Hub do
   }
 
   def create_default_hub(%Dash.Account{} = account, fxa_email) do
-    # TODO replace with request to orchestrator with email for a round trip to get this information.
-    subdomain_and_name = rand_string(10)
+    # TODO These random strings are not very pleasant.
+    # Maybe use a friendlier name generator instead?
+    subdomain_and_name = Dash.Utils.rand_string(10)
 
     new_hub_params =
       %{
-        instance_uuid: fake_uuid(),
+        # TODO Decide whether we actually want an instance_uuid field.
+        # At the very least, we should not be using a fake uuid here.
+        instance_uuid: Dash.Utils.fake_uuid(),
         name: subdomain_and_name,
         subdomain: subdomain_and_name,
         status: :creating
@@ -96,30 +104,12 @@ defmodule Dash.Hub do
       |> Dash.Repo.insert!()
 
     with {:ok, _} <- Dash.OrchClient.create_hub(fxa_email, new_hub) do
+      # TODO Wait for hub to be fully available, then set status to :ready
       {:ok, new_hub}
     else
       # TODO Should we delete the hub from the db or set status = :error enum?
       {:error, err} -> {:error, err}
     end
-  end
-
-  defp rand_string(len) do
-    chars = "0123456789abcdef" |> String.graphemes()
-
-    1..len
-    |> Enum.map(fn _ -> chars |> Enum.take_random(1) end)
-    |> Enum.join("")
-  end
-
-  defp fake_uuid() do
-    [
-      rand_string(8),
-      rand_string(4),
-      rand_string(4),
-      rand_string(4),
-      rand_string(12)
-    ]
-    |> Enum.join("-")
   end
 
   def get_hub(hub_id, %Dash.Account{} = account) do
@@ -139,11 +129,30 @@ defmodule Dash.Hub do
   end
 
   def update_hub(hub_id, attrs, %Dash.Account{} = account) do
-    with %Dash.Hub{} = hub <- get_hub(hub_id, account) do
-      form_changeset(hub, attrs) |> Dash.Repo.update()
+    with %Dash.Hub{} = hub <- get_hub(hub_id, account),
+         {:ok, updated_hub} <- form_changeset(hub, attrs) |> Dash.Repo.update() do
+      if hub.subdomain != updated_hub.subdomain do
+        update_subdomain(hub, updated_hub)
+      else
+        {:ok, updated_hub}
+      end
     else
-      {:error, err} -> {:error, err}
-      err -> err
+      _err ->
+        # TODO Add logging here
+        {:error, :update_hub_failed}
+    end
+  end
+
+  defp update_subdomain(%Dash.Hub{} = previous_hub, %Dash.Hub{} = updated_hub) do
+    case Dash.OrchClient.update_subdomain(updated_hub) do
+      {:ok, _} ->
+        {:ok, updated_hub}
+
+      {:error, _} ->
+        # TODO Add logging here
+        # Revert the subdomain back to the previous one, since the orchestrator request failed.
+        updated_hub |> form_changeset(%{subdomain: previous_hub.subdomain}) |> Dash.Repo.update()
+        {:error, :subdomain_update_failed}
     end
   end
 
@@ -168,6 +177,7 @@ defmodule Dash.Hub do
     %{current_ccu: current_ccu, current_storage_mb: current_storage_mb}
   end
 
+  # TODO Move reticulum requests into a RetClient module.
   @ret_host_prefix "hc-"
   @ret_internal_port "4000"
   defp get_hub_internal_host_url(%Dash.Hub{} = hub) do

--- a/lib/dash/utils.ex
+++ b/lib/dash/utils.ex
@@ -1,0 +1,20 @@
+defmodule Dash.Utils do
+  def rand_string(len) do
+    chars = "0123456789abcdef" |> String.graphemes()
+
+    1..len
+    |> Enum.map(fn _ -> chars |> Enum.take_random(1) end)
+    |> Enum.join("")
+  end
+
+  def fake_uuid() do
+    [
+      rand_string(8),
+      rand_string(4),
+      rand_string(4),
+      rand_string(4),
+      rand_string(12)
+    ]
+    |> Enum.join("-")
+  end
+end

--- a/lib/dash_web/controllers/api/v1/hub_controller.ex
+++ b/lib/dash_web/controllers/api/v1/hub_controller.ex
@@ -40,14 +40,11 @@ defmodule DashWeb.Api.V1.HubController do
       {:ok, _} ->
         conn |> send_resp(200, "")
 
-      {:error, %Ecto.Changeset{}} ->
-        conn |> send_resp(400, Jason.encode!(%{error: :invalid_input})) |> halt()
+      {:error, :subdomain_update_failed = err} ->
+        conn |> send_resp(500, Jason.encode!(%{error: err})) |> halt()
 
       {:error, err} ->
         conn |> send_resp(400, Jason.encode!(%{error: err})) |> halt()
-
-      _ ->
-        conn |> send_resp(404, Jason.encode!(%{error: :not_found})) |> halt()
     end
   end
 

--- a/lib/mix/tasks/dash_tasks.ex
+++ b/lib/mix/tasks/dash_tasks.ex
@@ -55,9 +55,9 @@ defmodule Mix.Tasks.Dash.CreateHub do
 
     %Dash.Hub{}
     |> Dash.Hub.changeset(%{
-      instance_uuid: fake_uuid(),
+      instance_uuid: Dash.Utils.fake_uuid(),
       name: hub_name,
-      subdomain: rand_string(10),
+      subdomain: Dash.Utils.rand_string(10),
       tier: :free,
       ccu_limit: 5,
       storage_limit_mb: 100,
@@ -66,25 +66,6 @@ defmodule Mix.Tasks.Dash.CreateHub do
     |> Ecto.Changeset.put_assoc(:account, account)
     |> Dash.Repo.insert!()
     |> IO.inspect()
-  end
-
-  defp rand_string(len) do
-    chars = "0123456789abcdef" |> String.graphemes()
-
-    1..len
-    |> Enum.map(fn _ -> chars |> Enum.take_random(1) end)
-    |> Enum.join("")
-  end
-
-  defp fake_uuid() do
-    [
-      rand_string(8),
-      rand_string(4),
-      rand_string(4),
-      rand_string(4),
-      rand_string(12)
-    ]
-    |> Enum.join("-")
   end
 end
 

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -1,14 +1,20 @@
 defmodule DashWeb.Api.V1.HubControllerTest do
   use DashWeb.ConnCase
   import DashWeb.TestHelpers
+  import Mox
+  import Plug.Conn.Status, only: [code: 1]
 
-  setup_all do
+  setup_all context do
     Mox.defmock(Dash.HttpMock, for: HTTPoison.Base)
-    merge_module_config(:dash, Dash.Hub, %{:http_client => Dash.HttpMock})
+    merge_module_config(:dash, Dash.Hub, http_client: Dash.HttpMock)
+    merge_module_config(:dash, Dash.OrchClient, http_client: Dash.HttpMock)
 
     on_exit(fn ->
-      merge_module_config(:dash, Dash.Hub, %{:http_client => nil})
+      merge_module_config(:dash, Dash.Hub, http_client: nil)
+      merge_module_config(:dash, Dash.OrchClient, http_client: nil)
     end)
+
+    verify_on_exit!(context)
   end
 
   describe "Hub API" do
@@ -16,11 +22,12 @@ defmodule DashWeb.Api.V1.HubControllerTest do
       Dash.HttpMock
       |> Mox.expect(:get, 2, fn url, _headers, _options ->
         cond do
-          url =~ ~r/presence$/ ->
-            {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{count: 3})}}
+          url =~ ~r/\/presence$/ ->
+            {:ok, %HTTPoison.Response{status_code: code(:ok), body: Poison.encode!(%{count: 3})}}
 
-          url =~ ~r/storage$/ ->
-            {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{storage_mb: 10})}}
+          url =~ ~r/\/storage$/ ->
+            {:ok,
+             %HTTPoison.Response{status_code: code(:ok), body: Poison.encode!(%{storage_mb: 10})}}
         end
       end)
 
@@ -30,60 +37,121 @@ defmodule DashWeb.Api.V1.HubControllerTest do
         conn
         |> put_test_token()
         |> get("/api/v1/hubs")
-        |> json_response(200)
+        |> json_response(:ok)
 
       %{"currentCcu" => 3, "currentStorageMb" => 10} = hub
     end
 
     test "should allow changing the name of a hub", %{conn: conn} do
       %{hub: hub} = create_test_account_and_hub()
-
       assert hub.name === "test hub"
 
-      conn
-      |> put_test_token()
-      |> patch_hub(hub, %{name: "new name"})
-      |> response(200)
-
-      %{"name" => "new name"} =
-        conn
-        |> put_test_token()
-        |> get("/api/v1/hubs/#{hub.hub_id}")
-        |> json_response(200)
+      conn |> patch_hub(hub, %{name: "new name"}, expected_status: :ok)
+      %{"name" => "new name"} = get_hub(conn, hub)
     end
 
     test "should ignore changes to the storage limit", %{conn: conn} do
       %{hub: hub} = create_test_account_and_hub()
-
       assert hub.storage_limit_mb === 100
 
-      conn
-      |> put_test_token()
-      |> patch_hub(hub, %{storageLimitMb: 10000})
-      |> response(200)
-
-      %{"storageLimitMb" => 100} =
-        conn
-        |> put_test_token()
-        |> get("/api/v1/hubs/#{hub.hub_id}")
-        |> json_response(200)
+      conn |> patch_hub(hub, %{storageLimitMb: 10000}, expected_status: :ok)
+      %{"storageLimitMb" => 100} = get_hub(conn, hub)
     end
 
     test "should error if name contains too many characters", %{conn: conn} do
       %{hub: hub} = create_test_account_and_hub()
 
-      long_name = 1..50 |> Enum.map(fn _ -> "a" end) |> Enum.join("")
+      long_name = String.duplicate("a", 25)
+      conn |> patch_hub(hub, %{name: long_name}, expected_status: :bad_request)
+    end
 
-      conn
-      |> put_test_token()
-      |> patch_hub(hub, %{name: long_name})
-      |> response(400)
+    test "should submit subdomain change to orchestrator", %{conn: conn} do
+      mock_orch_patch()
+
+      %{hub: hub} = create_test_account_and_hub()
+      assert hub.subdomain =~ "test-subdomain"
+
+      conn |> patch_subdomain(hub, "new-subdomain", expected_status: :ok)
+      %{"subdomain" => "new-subdomain"} = get_hub(conn, hub)
+    end
+
+    test "should error on duplicate subdomains", %{conn: conn} do
+      mock_orch_patch()
+
+      %{hub: hub_one} = create_test_account_and_hub()
+      %{hub: hub_two} = create_test_account_and_hub()
+
+      conn |> patch_subdomain(hub_one, "new-subdomain", expected_status: :ok)
+
+      conn |> patch_subdomain(hub_two, "new-subdomain", expected_status: :bad_request)
+    end
+
+    test "should error on invalid subdomains", %{conn: conn} do
+      mock_orch_patch()
+
+      %{hub: hub} = create_test_account_and_hub()
+      assert hub.subdomain =~ "test-subdomain"
+
+      long_subdomain = String.duplicate("a", 64)
+      conn |> patch_subdomain(hub, long_subdomain, expected_status: :bad_request)
+
+      subdomain_with_starting_hyphen = "-test-subdomain"
+      conn |> patch_subdomain(hub, subdomain_with_starting_hyphen, expected_status: :bad_request)
+
+      subdomain_with_ending_hyphen = "test-subdomain-"
+      conn |> patch_subdomain(hub, subdomain_with_ending_hyphen, expected_status: :bad_request)
+
+      subdomain_with_underscore = "test_subdomain"
+      conn |> patch_subdomain(hub, subdomain_with_underscore, expected_status: :bad_request)
+
+      subdomain_with_invalid_chars = "`~!@#$%^&*()+=;:'\"\\|[{]},<.>/?"
+      conn |> patch_subdomain(hub, subdomain_with_invalid_chars, expected_status: :bad_request)
+
+      subdomain_with_unicode = "◝(ᵔᵕᵔ)◜"
+      conn |> patch_subdomain(hub, subdomain_with_unicode, expected_status: :bad_request)
+
+      %{"subdomain" => final_subdomain} = get_hub(conn, hub)
+      assert final_subdomain =~ "test-subdomain"
+    end
+
+    test "should error if orch request fails", %{conn: conn} do
+      mock_orch_patch(response: :error, status_code: :internal_server_error)
+
+      %{hub: hub} = create_test_account_and_hub()
+      assert hub.subdomain =~ "test-subdomain"
+
+      conn |> patch_subdomain(hub, "new-subdomain", expected_status: :internal_server_error)
+
+      %{"subdomain" => final_subdomain} = get_hub(conn, hub)
+      assert final_subdomain =~ "test-subdomain"
     end
   end
 
-  defp patch_hub(conn, %Dash.Hub{} = hub, %{} = body) do
+  defp mock_orch_patch(opts \\ [response: :ok, status_code: :ok]) do
+    Mox.expect(Dash.HttpMock, :patch, 1, fn url, _body ->
+      cond do
+        url =~ ~r/\/hc_instance\// ->
+          {opts[:response], %HTTPoison.Response{status_code: code(opts[:status_code])}}
+      end
+    end)
+  end
+
+  defp get_hub(conn, hub) do
     conn
+    |> put_test_token()
+    |> get("/api/v1/hubs/#{hub.hub_id}")
+    |> json_response(:ok)
+  end
+
+  defp patch_hub(conn, %Dash.Hub{} = hub, %{} = body, expected_status: expected_status) do
+    conn
+    |> put_test_token()
     |> put_req_header("content-type", "application/json")
     |> patch("/api/v1/hubs/#{hub.hub_id}", Jason.encode!(body))
+    |> response(expected_status)
+  end
+
+  defp patch_subdomain(conn, hub, subdomain, expected_status: expected_status) do
+    conn |> patch_hub(hub, %{subdomain: subdomain}, expected_status: expected_status)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -39,12 +39,12 @@ defmodule DashWeb.TestHelpers do
     hub =
       %Dash.Hub{}
       |> Dash.Hub.changeset(%{
-        instance_uuid: "db810793-d738-5ca8-ea16-8dd699ef39e2",
+        instance_uuid: Dash.Utils.fake_uuid(),
         name: "test hub",
         ccu_limit: 20,
         storage_limit_mb: 100,
         tier: :mvp,
-        subdomain: "test-subdomain",
+        subdomain: "test-subdomain-#{Dash.Utils.rand_string(10)}",
         status: :ready
       })
       |> Ecto.Changeset.put_assoc(:account, account)
@@ -54,7 +54,7 @@ defmodule DashWeb.TestHelpers do
   end
 
   def merge_module_config(app, key, configs) do
-    current_config = Application.get_env(app, key, %{})
-    Application.put_env(app, key, Map.merge(current_config, configs))
+    current_config = Application.get_env(app, key, [])
+    Application.put_env(app, key, Keyword.merge(current_config, configs))
   end
 end


### PR DESCRIPTION
- hub_controller can now handle subdomain updates in update_hub.
- Added basic subdomain validation rules.
- Added request to orchestrator to update subdomain as needed, and after validation passes.
- Added various test scenarios for subdomain updates.
- Refactored hub_controller_test to improve readability.
- Moves rand_string and fake_uuid to shared Dash.Utils module.