### PR TITLE
Fixed Mix.env() error and added dev.exs variable

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -23,7 +23,7 @@ auth_pub_key =
         "-----END RSA PUBLIC KEY-----\n"
   end
 
-config :dash, Dash.Hub, skip_http_client: true
+config :dash, Dash.Hub, use_fake_hub_stats: true
 
 # Configure your database
 config :dash, Dash.Repo,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,7 +29,7 @@ if config_env() == :prod do
     socket_options: maybe_ipv6
 
   # For sending requests to deployed hub reticulum nodes
-  config :dash, Dash.Hub, dashboard_ret_access_key: System.get_env("DASHBOARD_ACCESS_KEY")
+  config :dash, Dash.RetClient, dashboard_ret_access_key: System.get_env("DASHBOARD_ACCESS_KEY")
 
   # Credentials for site-wide basic auth
   config :dash, DashWeb.Plugs.BasicAuth,

--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -151,7 +151,7 @@ defmodule Dash.Hub do
 
   # Returns current CCU and Storage
   defp get_hub_usage_stats(%Dash.Hub{} = hub) do
-    if Application.get_env(:dash, Dash.Hub)[:skip_http_client] === true do
+    if Application.get_env(:dash, Dash.Hub)[:use_fake_hub_stats] === true do
       %{current_ccu: 10, current_storage_mb: 20}
     else
       current_ccu =

--- a/lib/dash/ret_client.ex
+++ b/lib/dash/ret_client.ex
@@ -1,5 +1,5 @@
 defmodule Dash.RetClient do
-  @ret_access_key Application.get_env(:dash, Dash.Hub)[:dashboard_ret_access_key]
+  @ret_access_key Application.get_env(:dash, Dash.RetClient)[:dashboard_ret_access_key]
 
   @ret_host_prefix "ret.hc-"
   @ret_host_postfix ".svc.cluster.local"


### PR DESCRIPTION
Removed `Mix.env()` and instead uses a skip_client variable in dev.exs