### PR TITLE
Fix hub loading state. Put isForbidden on account

### DIFF
--- a/assets/src/components/display/ForbiddenWrapper.js
+++ b/assets/src/components/display/ForbiddenWrapper.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { useHubs } from "../hooks/hubs";
+import { useAccount } from "../hooks/account";
 import { UserNotFound } from "./UserNotFound";
 import { Spinner } from "../common/Spinner";
 
 export function ForbiddenWrapper({ children }) {
-  const { isLoading, isForbidden } = useHubs();
-  return <>{isLoading ? <Spinner /> : isForbidden ? <UserNotFound /> : children}</>;
+  const { isLoading, account } = useAccount();
+  return <>{isLoading ? <Spinner /> : account.isForbidden ? <UserNotFound /> : children}</>;
 }
 
 ForbiddenWrapper.propTypes = {

--- a/assets/src/components/display/Nav.js
+++ b/assets/src/components/display/Nav.js
@@ -4,13 +4,13 @@ import { useLocation } from "react-router-dom";
 import "./Nav.css";
 import { Link } from "react-router-dom";
 import { IconBackButton } from "../common/icons";
-import { useHubs } from "../hooks/hubs";
+import { useAccount } from "../hooks/account";
 
 export function Nav() {
-  const { isLoading, isForbidden } = useHubs();
+  const { isLoading, account } = useAccount();
   const location = useLocation();
   const isHubsSettings = location.pathname.startsWith("/hubs/");
-  const isAllowed = !isLoading && !isForbidden;
+  const isAllowed = !isLoading && !account.isForbidden;
   const title = isAllowed ? (isHubsSettings ? "Hub Settings" : "Dashboard") : "";
   const showBackButton = isAllowed && isHubsSettings;
   return (

--- a/assets/src/components/hooks/hubs.js
+++ b/assets/src/components/hooks/hubs.js
@@ -9,11 +9,7 @@ export function useHubs() {
   const dispatch = useDispatch();
   const hubs = useSelector((state) => hubEntitySelectors.selectAll(state));
   const isInitialized = useSelector(selectIsInitialized);
-  const { data, error, isLoading, isError, isSuccess } = useGetHubsQuery({}, { skip: isInitialized });
-
-  // TODO isForbidden should probably be an isAllowed property of the accounts API response.
-  // Manage unauthorized email
-  const isForbidden = isError && error.status === 403;
+  const { data, isLoading, isError, isSuccess } = useGetHubsQuery({}, { skip: isInitialized });
 
   const shouldUpdateHubEntities = !isInitialized && data;
   useEffect(() => {
@@ -25,7 +21,7 @@ export function useHubs() {
   const hasHubs = !!hubs.length;
   const isReady = isSuccess || isInitialized;
 
-  return { hubs, hasHubs, isLoading, isError, isReady, isForbidden };
+  return { hubs, hasHubs, isLoading, isError, isReady };
 }
 
 export function useHub(hubId) {
@@ -33,12 +29,9 @@ export function useHub(hubId) {
   const hubEntity = useSelector((state) => hubEntitySelectors.selectById(state, hubId));
 
   const hasHubEntity = !!hubEntity;
-  const { data, error, isLoading, isError, isSuccess } = useGetHubQuery({ hubId }, { skip: hasHubEntity });
+  const { data, isLoading, isError, isSuccess } = useGetHubQuery({ hubId }, { skip: hasHubEntity });
 
   if (!hasHubEntity && data) dispatch(setHubEntity(data));
-
-  // Manage unauthorized email
-  const isForbidden = isError && error.status === 403;
 
   const currentHub = useSelector(selectCurrentHub);
   if (hasHubEntity && !currentHub) dispatch(setCurrentHub(hubEntity));
@@ -60,6 +53,5 @@ export function useHub(hubId) {
     isError,
     isReady,
     isSubmitting,
-    isForbidden,
   };
 }

--- a/assets/src/components/store/account.js
+++ b/assets/src/components/store/account.js
@@ -5,6 +5,7 @@ export const accountSlice = createSlice({
   initialState: {
     isInitialized: false,
     isLoggedIn: false,
+    isForbidden: false,
     hasHubs: false,
     profilePicture: "",
     displayName: "",
@@ -18,9 +19,11 @@ export const accountSlice = createSlice({
       state.profilePicture = action.payload.profilePic;
       state.displayName = action.payload.displayName;
       state.email = action.payload.email;
+      state.isForbidden = action.payload.isForbidden;
     },
     logOut(state) {
       state.isLoggedIn = false;
+      state.isForbidden = false;
       state.hasHubs = false;
       state.profilePicture = "";
       state.displayName = "";

--- a/lib/dash/approved_email.ex
+++ b/lib/dash/approved_email.ex
@@ -62,6 +62,10 @@ defmodule Dash.ApprovedEmail do
     end
   end
 
+  def is_forbidden(email) do
+    is_enabled() and !has_email(email)
+  end
+
   def has_email(email) when is_binary(email) do
     hashed_email = hash_email(email)
     Repo.exists?(from e in ApprovedEmail, where: e.email_hash == ^hashed_email)
@@ -69,6 +73,10 @@ defmodule Dash.ApprovedEmail do
 
   def hash_email(email) do
     email |> String.downcase() |> hash()
+  end
+
+  defp is_enabled() do
+    Application.get_env(:dash, __MODULE__)[:enabled] !== false
   end
 
   defp hash(plaintext, key \\ default_secret_key()) do

--- a/lib/dash_web/controllers/api/v1/account_controller.ex
+++ b/lib/dash_web/controllers/api/v1/account_controller.ex
@@ -6,12 +6,15 @@ defmodule DashWeb.Api.V1.AccountController do
     # where we need to build the users's first hub, and subsequent logins,
     # where the user's hub is available, but is yet to be loaded in the frontend.
     has_hubs = Dash.Hub.has_hubs(conn.assigns[:account])
+    fxa_account_info = conn.assigns[:fxa_account_info]
+    is_forbidden = Dash.ApprovedEmail.is_forbidden(fxa_account_info.fxa_email)
 
     conn
     |> render(
       "index.json",
-      fxa_account_info: conn.assigns[:fxa_account_info],
-      has_hubs: has_hubs
+      fxa_account_info: fxa_account_info,
+      has_hubs: has_hubs,
+      is_forbidden: is_forbidden
     )
   end
 end

--- a/lib/dash_web/views/api/v1/account_view.ex
+++ b/lib/dash_web/views/api/v1/account_view.ex
@@ -5,13 +5,15 @@ defmodule DashWeb.Api.V1.AccountView do
 
   def render("index.json", %{
         fxa_account_info: %Dash.FxaAccountInfo{} = fxa_account_info,
-        has_hubs: has_hubs
+        has_hubs: has_hubs,
+        is_forbidden: is_forbidden
       }) do
     %{
       displayName: fxa_account_info.fxa_display_name,
       profilePic: fxa_account_info.fxa_pic,
       email: fxa_account_info.fxa_email,
-      hasHubs: has_hubs
+      hasHubs: has_hubs,
+      isForbidden: is_forbidden
     }
   end
 end


### PR DESCRIPTION
- Return isForbidden on the account API so that we don't have to mix that information with a request to the hubs API.
- Have ForbiddenWrapper and other components use the account for isForbidden
- Remove isForbidden from the hub hooks