### PR TITLE
Configure and enable ApprovedEmail behavior in a consistent manner

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -63,7 +63,7 @@ config :dash, DashWeb.Plugs.BasicAuth,
   username: "local",
   password: "pass"
 
-config :dash, DashWeb.Plugs.ApprovedEmailAuth, enabled: false
+config :dash, Dash.ApprovedEmail, enabled: false
 
 config :dash, Dash.OrchClient, orch_host: "turkey-orch.local"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,7 +24,7 @@ config :dash, Dash.AppConfig, host: "dashboard.cluster.turkey.local"
 
 config :dash, DashWeb.Plugs.BasicAuth, enabled: false
 
-config :dash, DashWeb.Plugs.ApprovedEmailAuth, enabled: false
+config :dash, Dash.ApprovedEmail, enabled: false
 
 # In test we don't send emails.
 config :dash, Dash.Mailer, adapter: Swoosh.Adapters.Test

--- a/lib/dash/approved_email.ex
+++ b/lib/dash/approved_email.ex
@@ -75,7 +75,8 @@ defmodule Dash.ApprovedEmail do
     email |> String.downcase() |> hash()
   end
 
-  defp is_enabled() do
+  def is_enabled() do
+    # Default to enabled, unless the config is explicitly set to false.
     Application.get_env(:dash, __MODULE__)[:enabled] !== false
   end
 

--- a/lib/dash_web/plugs/approved_email_auth.ex
+++ b/lib/dash_web/plugs/approved_email_auth.ex
@@ -9,10 +9,7 @@ defmodule DashWeb.Plugs.ApprovedEmailAuth do
   def init(default), do: default
 
   def call(conn, _options) do
-    # Default to enabled, unless the config is explicitly set to false.
-    approved_email_auth_enabled = Application.get_env(:dash, __MODULE__)[:enabled] !== false
-
-    if approved_email_auth_enabled do
+    if Dash.ApprovedEmail.is_enabled() do
       check_if_approved_email(conn, conn.assigns[:fxa_account_info])
     else
       conn

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -6,7 +6,6 @@ defmodule DashWeb.Api.V1.HubControllerTest do
 
   setup_all context do
     setup_mocks_for_hubs()
-    Application.put_env(:dash, DashWeb.Plugs.ApprovedEmailAuth, enabled: false)
 
     on_exit(fn ->
       exit_mocks_for_hubs()

--- a/test/plugs/approved_email_auth_test.exs
+++ b/test/plugs/approved_email_auth_test.exs
@@ -7,22 +7,20 @@ defmodule DashWeb.Plugs.ApprovedEmailAuthTest do
   setup_all do
     setup_mocks_for_hubs()
 
-    on_exit(fn ->
-      exit_mocks_for_hubs()
-    end)
+    on_exit(fn -> exit_mocks_for_hubs() end)
   end
 
   describe "ApprovedEmailAuth Plug" do
     setup do
-      # Explicitly get a connection before each test
       clear_auth_config()
-      Application.put_env(:dash, DashWeb.Plugs.ApprovedEmailAuth, enabled: true)
+      Application.put_env(:dash, Dash.ApprovedEmail, enabled: true)
+      on_exit(fn -> Application.put_env(:dash, Dash.ApprovedEmail, enabled: false) end)
     end
 
     @valid_expiration token_expiry: ~N[3000-01-01 00:00:00]
 
     test "ApprovedEmails should not be enabled when disabled", %{conn: conn} do
-      Application.put_env(:dash, DashWeb.Plugs.ApprovedEmailAuth, enabled: false)
+      Application.put_env(:dash, Dash.ApprovedEmail, enabled: false)
 
       HubControllerTest.mock_hubs_get()
       HubControllerTest.mock_orch_post()


### PR DESCRIPTION
We were a bit hasty with #79 and didn't actually use the approved email "enabled" config correctly. This PR corrects it across the codebase.