### PR TITLE
Use logger to capture errors

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -29,8 +29,8 @@ config :dash, Dash.ApprovedEmail, enabled: false
 # In test we don't send emails.
 config :dash, Dash.Mailer, adapter: Swoosh.Adapters.Test
 
-# Print only warnings and errors during test
-config :logger, level: :warn
+# Print only logs that are critical and above
+config :logger, level: :critical
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/dash/approved_email.ex
+++ b/lib/dash/approved_email.ex
@@ -36,7 +36,7 @@ defmodule Dash.ApprovedEmail do
         Logger.info("Added email")
 
       {:error, error} ->
-        Logger.error("ERROR: Could not add email.")
+        Logger.error("Could not add email.")
         # Return tuple for tests
         {:error, error}
     end
@@ -58,7 +58,7 @@ defmodule Dash.ApprovedEmail do
         Logger.info("Deleted email")
 
       nil ->
-        Logger.error("ERROR: couldn't find email to delete")
+        Logger.error("Couldn't find email to delete")
     end
   end
 

--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -2,6 +2,7 @@ defmodule Dash.Hub do
   use Ecto.Schema
   import Ecto.Query
   import Ecto.Changeset
+  require Logger
   alias Dash.{Repo, RetClient}
 
   @primary_key {:hub_id, :id, autogenerate: true}
@@ -95,13 +96,16 @@ defmodule Dash.Hub do
       |> Ecto.Changeset.put_assoc(:account, account)
       |> Repo.insert!()
 
-    with {:ok, _} <- Dash.OrchClient.create_hub(fxa_email, new_hub) do
-      # TODO Wait for hub to be fully available, before setting status to :ready
-      new_hub = new_hub |> change(status: :ready) |> Dash.Repo.update!()
-      {:ok, new_hub}
-    else
-      # TODO Should we delete the hub from the db or set status = :error enum?
-      {:error, err} -> {:error, err}
+    case Dash.OrchClient.create_hub(fxa_email, new_hub) do
+      {:ok, _} ->
+        # TODO Wait for hub to be fully available, before setting status to :ready
+        new_hub = new_hub |> change(status: :ready) |> Dash.Repo.update!()
+        {:ok, new_hub}
+
+      {:error, err} ->
+        Logger.error("Failed to create default hub #{inspect(err)}")
+        # TODO Should we delete the hub from the db or set status = :error enum?
+        {:error, err}
     end
   end
 
@@ -130,8 +134,8 @@ defmodule Dash.Hub do
         {:ok, updated_hub}
       end
     else
-      _err ->
-        # TODO Add logging here
+      err ->
+        Logger.error("Failed to update hub. #{inspect(err)}")
         {:error, :update_hub_failed}
     end
   end
@@ -141,8 +145,8 @@ defmodule Dash.Hub do
       {:ok, _} ->
         {:ok, updated_hub}
 
-      {:error, _} ->
-        # TODO Add logging here
+      {:error, err} ->
+        Logger.error("Failed to update subdomain. #{inspect(err)}")
         # Revert the subdomain back to the previous one, since the orchestrator request failed.
         updated_hub |> form_changeset(%{subdomain: previous_hub.subdomain}) |> Dash.Repo.update()
         {:error, :subdomain_update_failed}
@@ -154,22 +158,8 @@ defmodule Dash.Hub do
     if Application.get_env(:dash, Dash.Hub)[:use_fake_hub_stats] === true do
       %{current_ccu: 10, current_storage_mb: 20}
     else
-      current_ccu =
-        case RetClient.get_current_ccu(hub) do
-          {:ok, ccu} ->
-            ccu
-
-          {:error, error} ->
-            IO.inspect(["Error getting ccu", error])
-            nil
-        end
-
-      current_storage_mb =
-        case RetClient.get_current_storage_usage_mb(hub) do
-          {:ok, storage_mb} -> storage_mb
-          {:error, _} -> nil
-        end
-
+      current_ccu = RetClient.get_current_ccu(hub)
+      current_storage_mb = RetClient.get_current_storage_usage_mb(hub)
       %{current_ccu: current_ccu, current_storage_mb: current_storage_mb}
     end
   end

--- a/lib/dash/orch_client.ex
+++ b/lib/dash/orch_client.ex
@@ -14,13 +14,10 @@ defmodule Dash.OrchClient do
       storage_limit: (hub.storage_limit_mb / 1024) |> to_string()
     }
 
-    resp =
-      get_http_client().post(
-        "http://#{get_orch_host()}/hc_instance",
-        Jason.encode!(orch_hub_create_params)
-      )
-
-    IO.inspect(resp)
+    get_http_client().post(
+      "http://#{get_orch_host()}/hc_instance",
+      Jason.encode!(orch_hub_create_params)
+    )
   end
 
   def update_subdomain(%Dash.Hub{} = hub) do

--- a/lib/dash/ret_client.ex
+++ b/lib/dash/ret_client.ex
@@ -3,6 +3,8 @@ defmodule Dash.RetClient do
   This module handles requests to specific hub instance's reticulum backend.
   """
 
+  require Logger
+
   @ret_host_prefix "ret.hc-"
   @ret_host_postfix ".svc.cluster.local"
   @ret_internal_port "4000"
@@ -28,17 +30,17 @@ defmodule Dash.RetClient do
       # Reticulum returned the ccu correctly
       {:ok, %{status_code: 200, body: body}} ->
         %{"count" => count} = Poison.Parser.parse!(body)
-        {:ok, count}
+        count
 
       # Reticulum completed the request but did not return the ccu
-      {:ok, %{status_code: _} = response} ->
-        IO.inspect(response)
-        {:error, :no_ccu_returned}
+      {:ok, %{status_code: status_code}} ->
+        Logger.error("Failed to retrieve reticulum CCU. Status code: #{status_code}")
+        nil
 
       # An error occurred
       {:error, reason} ->
-        IO.inspect(reason)
-        {:error, reason}
+        Logger.error("Failed to retrieve reticulum CCU. Reason: #{reason}")
+        nil
     end
   end
 
@@ -47,15 +49,15 @@ defmodule Dash.RetClient do
     case fetch_ret_internal_endpoint(hub, @storage_endpoint) do
       {:ok, %{status_code: 200, body: body}} ->
         %{"storage_mb" => storage_mb} = Poison.Parser.parse!(body)
-        {:ok, storage_mb}
+        storage_mb
 
-      {:ok, _} ->
-        # TODO Log and error here when we introduce Logger
-        {:error, :no_storage_returned}
+      {:ok, %{status_code: status_code}} ->
+        Logger.error("Failed to retrieve reticulum storage usage. Status code: #{status_code}")
+        nil
 
       {:error, reason} ->
-        # TODO Log and error here when we introduce Logger
-        {:error, reason}
+        Logger.error("Failed to retrieve reticulum storage usage. Reason: #{reason}")
+        nil
     end
   end
 


### PR DESCRIPTION
- Replaced TODOs and IO.inspect with Logger calls
- Simplified RetClient so that we don't have to do error handling twice
- Changed the logger configuration in test, so that the test output isn't unnecessarily verbose