### PR TITLE
Update OrchClient to use the final API shape for subdomain updates

### DIFF
--- a/lib/dash/orch_client.ex
+++ b/lib/dash/orch_client.ex
@@ -22,8 +22,11 @@ defmodule Dash.OrchClient do
 
   def update_subdomain(%Dash.Hub{} = hub) do
     get_http_client().patch(
-      "http://#{get_orch_host()}/hc_instance/#{hub.hub_id}",
-      Jason.encode!(%{subdomain: hub.subdomain})
+      "http://#{get_orch_host()}/hc_instance",
+      Jason.encode!(%{
+        hub_id: hub.hub_id |> to_string,
+        subdomain: hub.subdomain
+      })
     )
   end
 

--- a/test/dash/orch_client_test.exs
+++ b/test/dash/orch_client_test.exs
@@ -1,0 +1,22 @@
+defmodule Dash.OrchClientTest do
+  use ExUnit.Case
+  import DashWeb.TestHelpers
+  import Mox, only: [verify_on_exit!: 1]
+
+  setup_all context do
+    setup_mocks_for_hubs()
+    on_exit(fn -> exit_mocks_for_hubs() end)
+    verify_on_exit!(context)
+  end
+
+  test "should patch subdomain with the correct API shape" do
+    Mox.expect(Dash.HttpMock, :patch, 1, fn url, body_str ->
+      assert url =~ ~r/\/hc_instance$/
+
+      body = Jason.decode!(body_str)
+      assert %{"hub_id" => "1234", "subdomain" => "newsubdomain"} = body
+    end)
+
+    Dash.OrchClient.update_subdomain(%Dash.Hub{hub_id: 1234, subdomain: "newsubdomain"})
+  end
+end

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -117,7 +117,7 @@ defmodule DashWeb.Api.V1.HubControllerTest do
   defp mock_orch_patch(opts \\ [response: :ok, status_code: :ok]) do
     Mox.expect(Dash.HttpMock, :patch, 1, fn url, _body ->
       cond do
-        url =~ ~r/\/hc_instance\// ->
+        url =~ ~r/\/hc_instance$/ ->
           {opts[:response], %HTTPoison.Response{status_code: code(opts[:status_code])}}
       end
     end)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -71,5 +71,7 @@ defmodule DashWeb.TestHelpers do
   end
 
   def exit_mocks_for_hubs() do
+    merge_module_config(:dash, Dash.Hub, http_client: nil)
+    merge_module_config(:dash, Dash.OrchClient, http_client: nil)
   end
 end


### PR DESCRIPTION
The final orchestrator API for updating a subdomain expects hub_id to be part of the body, not the URL. Also added a test to verify the API shape.