### PR TITLE
[ENG] Fix GitHub Actions For Storybook

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,7 +2,7 @@ name: Storybook
 on:
   push:
     branches:
-      - HUBSTRKY-421
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Storybook still runs off of React 16/17 and we are on 18. Need to update Storybook Deploy to install legacy peer dependencies to work.