### PR TITLE
Fix HTTP request parameters

### DIFF
--- a/lib/dash/orch_client.ex
+++ b/lib/dash/orch_client.ex
@@ -21,6 +21,7 @@ defmodule Dash.OrchClient do
     get_http_client().post(
       orch_hub_endpoint(),
       Jason.encode!(orch_hub_create_params),
+      [],
       hackney: [:insecure]
     )
   end
@@ -32,6 +33,7 @@ defmodule Dash.OrchClient do
         hub_id: hub.hub_id |> to_string,
         subdomain: hub.subdomain
       }),
+      [],
       hackney: [:insecure]
     )
   end

--- a/lib/dash/ret_client.ex
+++ b/lib/dash/ret_client.ex
@@ -30,6 +30,7 @@ defmodule Dash.RetClient do
 
     http_client.get(
       ret_host_url(hub) <> @health_endpoint,
+      [],
       hackney: [:insecure]
     )
   end

--- a/test/dash/orch_client_test.exs
+++ b/test/dash/orch_client_test.exs
@@ -10,7 +10,7 @@ defmodule Dash.OrchClientTest do
   end
 
   test "should patch subdomain with the correct API shape" do
-    Mox.expect(Dash.HttpMock, :patch, 1, fn url, body_str, _opts ->
+    Mox.expect(Dash.HttpMock, :patch, 1, fn url, body_str, _headers, _opts ->
       assert url =~ ~r/\/hc_instance$/
 
       body = Jason.decode!(body_str)

--- a/test/plugs/approved_email_auth_test.exs
+++ b/test/plugs/approved_email_auth_test.exs
@@ -23,7 +23,6 @@ defmodule DashWeb.Plugs.ApprovedEmailAuthTest do
 
       mock_hubs_get()
       mock_orch_post()
-      stub_hubs_success_health_check()
 
       conn =
         conn
@@ -47,7 +46,6 @@ defmodule DashWeb.Plugs.ApprovedEmailAuthTest do
     test "should respond with 200 if user is on ApprovedEmailList and authorized", %{conn: conn} do
       mock_hubs_get()
       mock_orch_post()
-      stub_hubs_success_health_check()
 
       email = get_test_email()
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -79,13 +79,16 @@ defmodule DashWeb.TestHelpers do
   # Required mocks for GET hubs requests
   def mock_hubs_get() do
     Dash.HttpMock
-    |> Mox.expect(:get, 2, fn url, _headers, _options ->
+    |> Mox.stub(:get, fn url, _headers, _options ->
       cond do
         url =~ ~r/presence$/ ->
           {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{count: 3})}}
 
         url =~ ~r/storage$/ ->
           {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{storage_mb: 10})}}
+
+        url =~ ~r/health$/ ->
+          {:ok, %HTTPoison.Response{status_code: 200}}
 
         true ->
           Logger.warn(
@@ -97,23 +100,8 @@ defmodule DashWeb.TestHelpers do
 
   def mock_orch_post() do
     Dash.HttpMock
-    |> Mox.expect(:post, fn _url, _body, _opts ->
+    |> Mox.expect(:post, fn _url, _body, _headers, _opts ->
       {:ok, %HTTPoison.Response{status_code: 200}}
-    end)
-  end
-
-  def stub_hubs_success_health_check() do
-    Dash.HttpMock
-    |> Mox.stub(:get, fn url, _headers ->
-      cond do
-        url =~ ~r/health$/ ->
-          {:ok, %HTTPoison.Response{status_code: 200}}
-
-        true ->
-          Logger.warn(
-            "Inside test, hit set up in stub_hubs_success_health_check/0, but GET request URL did not match /health, did you mean to do that?"
-          )
-      end
     end)
   end
 end


### PR DESCRIPTION
HTTPoison's options parameter must be specified after the headers parameter. It was incorrect to pass hackney options as the third parameter.

As a side effect of fixing the request parameters, the mocks we were using started clashing with each other, since their parities were now the same. To fix this, I changed `mock_hubs_get` to include the health endpoint, and changed it from an `expect` to a `stub`, since we didn't actually need to count the number of requests for that mock.

The order or the mock calls also had to be changed in some tests, since we need to setup `stub` mocks after we setup `expect` mocks.