### PR TITLE
Call reticulum to rewrite assets for a subdomain update

### DIFF
--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -270,7 +270,8 @@ defmodule Dash.Hub do
     Task.Supervisor.async(Dash.TaskSupervisor, fn ->
       with {:ok, %{status_code: status_code}} when status_code < 400 <-
              Dash.OrchClient.update_subdomain(updated_hub),
-           {:ok} <- Dash.RetClient.wait_until_healthy(updated_hub) do
+           {:ok} <- Dash.RetClient.wait_until_healthy(updated_hub),
+           {:ok} <- Dash.RetClient.rewrite_assets(previous_hub, updated_hub) do
         set_hub_to_ready(updated_hub)
       else
         err ->

--- a/lib/dash/ret_client.ex
+++ b/lib/dash/ret_client.ex
@@ -4,6 +4,7 @@ defmodule Dash.RetClient do
   """
   require Logger
   use Retry
+  alias Dash.{AppConfig}
 
   @ret_host_prefix "ret.hc-"
   @ret_host_postfix ".svc.cluster.local"
@@ -19,21 +20,31 @@ defmodule Dash.RetClient do
     do: fetch_ret_internal_endpoint(hub.hub_id, endpoint)
 
   defp fetch_ret_internal_endpoint(hub_id, endpoint, opts \\ []) when is_integer(hub_id) do
-    # Make the http client module configurable so that we can mock it out in tests.
-    http_client = get_http_client() || HTTPoison
-
-    http_client.get(
+    get_http_client().get(
       ret_host_url(hub_id) <> @ret_internal_scope <> endpoint,
       [{"x-ret-dashboard-access-key", get_ret_access_key()}],
       [hackney: [:insecure]] ++ opts
     )
   end
 
+  defp post_ret_internal_endpoint(%Dash.Hub{} = hub, endpoint, %{} = body),
+    do: post_ret_internal_endpoint(hub.hub_id, endpoint, body)
+
+  defp post_ret_internal_endpoint(hub_id, endpoint, %{} = body) do
+    get_http_client().post(
+      ret_host_url(hub_id) <> @ret_internal_scope <> endpoint,
+      Jason.encode!(body),
+      [
+        {"x-ret-dashboard-access-key", get_ret_access_key()},
+        {"content-type", "application/json"}
+      ],
+      hackney: [:insecure]
+    )
+  end
+
   @health_endpoint "/health"
   defp fetch_health_endpoint(%Dash.Hub{} = hub) do
-    http_client = get_http_client() || HTTPoison
-
-    http_client.get(
+    get_http_client().get(
       ret_host_url(hub) <> @health_endpoint,
       [],
       hackney: [:insecure]
@@ -104,6 +115,35 @@ defmodule Dash.RetClient do
     end
   end
 
+  @rewrite_assets_endpoint "rewrite_assets"
+  def rewrite_assets(%Dash.Hub{} = previous_hub, %Dash.Hub{} = updated_hub) do
+    cluster_domain = AppConfig.cluster_domain()
+    old_domain = "#{previous_hub.subdomain}.#{cluster_domain}"
+    new_domain = "#{updated_hub.subdomain}.#{cluster_domain}"
+
+    case post_ret_internal_endpoint(updated_hub, @rewrite_assets_endpoint, %{
+           "old_domain" => old_domain,
+           "new_domain" => new_domain
+         }) do
+      {:ok, %{status_code: 200}} ->
+        {:ok}
+
+      {:ok, %{status_code: status_code}} ->
+        Logger.error(
+          "Failed to rewrite assets from: #{old_domain} to #{new_domain}. Status code: #{status_code}"
+        )
+
+        {:error, :rewrite_assets_failed}
+
+      {:error, err} ->
+        Logger.error(
+          "Failed to rewrite assets from: #{old_domain} to #{new_domain}. Error: #{inspect(err)}"
+        )
+
+        {:error, :rewrite_assets_failed}
+    end
+  end
+
   defp get_ret_access_key() do
     Application.get_env(:dash, Dash.RetClient)[:dashboard_ret_access_key]
   end
@@ -116,7 +156,8 @@ defmodule Dash.RetClient do
     Application.get_env(:dash, Dash.RetClient)[:wait_ms]
   end
 
-  def get_http_client() do
-    Application.get_env(:dash, Dash.Hub)[:http_client]
+  defp get_http_client() do
+    # Make the http client module configurable so that we can mock it out in tests.
+    Application.get_env(:dash, Dash.Hub)[:http_client] || HTTPoison
   end
 end


### PR DESCRIPTION
Calls the rewrite_assets endpoint introduced in https://github.com/mozilla/reticulum/pull/608 so that assets are rewritten when a subdomain is updated