### PR TITLE
Fix spinner animation in Chrome

### DIFF
--- a/assets/src/components/common/Spinner.css
+++ b/assets/src/components/common/Spinner.css
@@ -1,9 +1,9 @@
 @keyframes rotate {
   from {
-    rotate: 0;
+    transform: rotate(0);
   }
   to {
-    rotate: 360deg;
+    transform: rotate(360deg);
   }
 }
 .spinner-container {


### PR DESCRIPTION
TIL `rotate` is a relatively new CSS property that doesn't exist in the stable versions of Chrome.