### PR TITLE
Fix hub stat type conversion

### DIFF
--- a/lib/dash/hub_stat.ex
+++ b/lib/dash/hub_stat.ex
@@ -19,7 +19,7 @@ defmodule Dash.HubStat do
         %{
           hub_id: hub_id,
           measured_at: measured_at,
-          storage_mb: storage_mb
+          storage_mb: floor(storage_mb)
         }
     end
   end

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -25,7 +25,7 @@ defmodule DashWeb.Api.V1.HubControllerTest do
         |> get("/api/v1/hubs")
         |> json_response(:ok)
 
-      %{"currentCcu" => 3, "currentStorageMb" => 10} = hub
+      %{"currentCcu" => 3, "currentStorageMb" => 10.5} = hub
     end
 
     test "should allow access to a user's hub", %{conn: conn} do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -86,7 +86,7 @@ defmodule DashWeb.TestHelpers do
           {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{count: 3})}}
 
         url =~ ~r/storage$/ ->
-          {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{storage_mb: 10})}}
+          {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{storage_mb: 10.5})}}
 
         url =~ ~r/health$/ ->
           {:ok, %HTTPoison.Response{status_code: 200}}


### PR DESCRIPTION
The scheduled job was failing on-cluster because reticulum returns a float, and we were trying to insert it into an integer field in the hubstats table.

```
(Ecto.ChangeError) value `47.06640625` for `Dash.HubStat.storage_mb` in `insert_all` does not match type :integer
```