### PR TITLE
Fix client API call

### DIFF
--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -3,22 +3,20 @@ import { useEffect } from 'react'
 import Head from "next/head"
 import { setAccount, logOut } from '../store/accountSlice'
 import { useDispatch } from 'react-redux'
-import axios from 'axios'
+import axios, { AxiosRequestHeaders } from 'axios'
 import { HubT, AccountT } from 'types/General'
 import { API_SERVER } from 'config'
 
 const fetchData = async (context: GetServerSidePropsContext, resource: string) => {
   const { cookie, accept, host, connection } = context.req.headers
-
-  return await axios.get(`${API_SERVER}/api/v1/${resource}`, {
-    headers: {
-      Accept: 'application/json',
+  const contextHeaders = {
       cookie: cookie ? cookie : '',
-      accept: accept ? accept : '',
-      host: host ? host : '',
-      connection: connection ? connection : ''
-    }
-  })
+      accept: accept ? accept : 'application/json',
+  } as AxiosRequestHeaders;
+  if (host) contextHeaders.host = host;
+  if (connection) contextHeaders.connection = connection;
+
+  return await axios.get(`${API_SERVER}/api/v1/${resource}`, { headers: contextHeaders })
     .then((response) => response.data)
 }
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -61,6 +61,8 @@ config :dash, Dash.FeatureFlags,
   ccu_selection: false,
   storage_selection: false
 
+config :dash, DashWeb.Plugs.BasicAuth, enabled: false
+
 config :dash, Dash.HubStat, enable_hub_stats: true
 
 config :dash, Dash.Scheduler,


### PR DESCRIPTION
This PR fixes the new client so that it works on-cluster. First, it changes the axios request in `pages/index.tsx` so that doesn't set the `connection` header to an empty string -- this was causing the request to error with the production version of the elixir API server. Secondly, it disables BasicAuth in the API server, since that would block the request immediately.