### PR TITLE
Fix cookie logout bug

### DIFF
--- a/lib/dash_web/controllers/logout_controller.ex
+++ b/lib/dash_web/controllers/logout_controller.ex
@@ -12,5 +12,5 @@ defmodule DashWeb.LogoutController do
   end
 
   def cluster_domain(conn),
-    do: ".#{conn.host |> String.split(".") |> Enum.take(-2) |> Enum.join(".")}"
+    do: conn.host
 end

--- a/lib/dash_web/plugs/auth.ex
+++ b/lib/dash_web/plugs/auth.ex
@@ -138,7 +138,6 @@ defmodule DashWeb.Plugs.Auth do
 
     Logger.warn("cookie_secure is #{cookie_secure}")
     Logger.warn("cookie domain is #{DashWeb.LogoutController.cluster_domain(conn)}")
-    Logger.warn("cookie domain is #{DashWeb.LogoutController.cluster_domain(conn)}")
 
     put_resp_cookie(
       conn,


### PR DESCRIPTION
This might work `conn.host`, might be DASH DOMAIN variable etc. 

Will delete the logs after this