### PR TITLE
Adds endpoint /api/v1/region

### DIFF
--- a/lib/dash_web/controllers/api/v1/region_controller.ex
+++ b/lib/dash_web/controllers/api/v1/region_controller.ex
@@ -1,16 +1,12 @@
 defmodule DashWeb.Api.V1.RegionController do
   use DashWeb, :controller
-  require Logger
 
   @region_header "x-client-region"
 
-  def index(conn, _) do
-    Logger.error("req_headers are #{inspect(conn.req_headers)}")
-
+  def show(conn, _) do
     region =
       case get_req_header(conn, @region_header) do
         [region] ->
-          Logger.error("region is #{inspect(region)}")
           region
 
         [] ->

--- a/lib/dash_web/router.ex
+++ b/lib/dash_web/router.ex
@@ -42,7 +42,7 @@ defmodule DashWeb.Router do
   # end
 
   scope "/api/v1", DashWeb do
-    resources("/region", Api.V1.RegionController, [:index])
+    resources("/region", Api.V1.RegionController, only: [:show], singleton: true)
   end
 
   scope "/api/v1", DashWeb do

--- a/test/dash_web/controllers/api/v1/region_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/region_controller_test.exs
@@ -1,8 +1,7 @@
 defmodule DashWeb.Api.V1.RegionControllerTest do
   use DashWeb.ConnCase
 
-  describe "index/2" do
-    @tag marked: true
+  describe "show/2" do
     test "should return region if header is present", %{conn: conn} do
       conn =
         conn
@@ -13,7 +12,6 @@ defmodule DashWeb.Api.V1.RegionControllerTest do
                Jason.encode!(%{region: "DE"})
     end
 
-    @tag marked: true
     test "should return nil if region is not present", %{conn: conn} do
       conn = get(conn, "/api/v1/region")
 


### PR DESCRIPTION
Adds endpoint to Dashboard API to get the x-client-region header from response

GET "/api/v1/region"
Response JSON `{region: "DE"}` / `{region: "US"}` / etc. 

If no header present will return 200 `{region: null}`