### PR TITLE
Exclude container-oriented files from containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,10 +48,11 @@ x-mutagen:
       ignore:
         paths:
           - ".DS_Store"
+          - ".dockerignore"
           - ".gitignore"
-          - "docker-compose.yml"
           - "Dockerfile"
-          - "/node_modules/"
+          - "docker-compose.yml"
+          - "/bin/"
         vcs: true
       mode: "two-way-resolved"
     code:


### PR DESCRIPTION
The files that manage and use containers needn’t exist on the containers themselves