### PR TITLE
Return exit code from bin/init

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -3,4 +3,6 @@ basedir=$(dirname "$0")/..
 mutagen-compose -f "$basedir/docker-compose.yml" run --rm server sh -c 'mix do deps.get, deps.compile, ecto.create' &&
 mutagen-compose -f "$basedir/docker-compose.yml" run --rm client sh -c '[ -d "node_modules" ] || npm ci'
 
+code=$?
 mutagen-compose down
+exit $code


### PR DESCRIPTION
We care about the exit code from the body of the script, not the cleanup step