### PR TITLE
Update home page to use a dedicated email addresss

### DIFF
--- a/marketing/components/shared/Subscribe/Subscribe.tsx
+++ b/marketing/components/shared/Subscribe/Subscribe.tsx
@@ -46,7 +46,7 @@ const Subscribe = ({ classProp = '' }: SubscribePropsT) => {
           <SubCard
             title="Business"
             cta="Contact us"
-            ctaUrl="mailto:hubs@mozilla.com?subject=Subscription inquiries"
+            ctaUrl="mailto:enterprise-hubs@mozilla.com?subject=Subscription inquiries"
           >
             <p>
               Need dedicated infrastructure, custom clients, or something else?


### PR DESCRIPTION
Change email address to a dedicated one separate from the general hubs@mozilla.com