### PR TITLE
Allow orchestration artifacts to be cleaned up

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This codebase can be run locally using either containers or bare metal.
 - Start containers with `bin/up`
 - Stop containers `bin/down`
 - Observe running containers with `bin/observe`[^1]
-- Restore the services to a fresh state with `bin/reset`
+- Remove all orchestration artifacts with `bin/clean`
 
 [^1]: Requires `tmux` and `watch` program files in the user’s path
 

--- a/bin/clean
+++ b/bin/clean
@@ -2,5 +2,4 @@
 basedir=$(readlink -f "$(dirname "$0")/..")
 
 mutagen-compose -f "$basedir/docker-compose.yml" down --volumes --rmi local &&
-rm -rf "$basedir/deps" &&
-"$basedir/bin/init"
+rm -rf "$basedir/deps"


### PR DESCRIPTION
Why
---
The `bin/reset` script was included with Hubs Compose instead of `bin/clean` because it wasn’t obvious whether or not such a script should remove cloned source code repositories.  The orchestration in Dash does not clone repositories, so it is not bound by the same limitations.  I mistakenly included `bin/reset` in the orchestration scripts when I prepared Dash for orchestration.  This change remedies that mistake.

With this change an orchestration reset can be performed by running `bin/clean` and `bin/init` in sequence.

What
----
* Replace `bin/reset` with `bin/clean`
* Update README