### PR TITLE
Fixed patch request for change email in RetClient

### DIFF
--- a/lib/dash/ret_client.ex
+++ b/lib/dash/ret_client.ex
@@ -167,8 +167,6 @@ defmodule Dash.RetClient do
 
   @change_email_for_login "change_email_for_login"
   def update_hub_admin_email(%Dash.Hub{hub_id: hub_id}, old_email, new_email) do
-    Logger.error("EMAIL CHANGE TODO UPDATE old: #{old_email}, new: #{new_email}")
-
     response =
       get_http_client().patch(
         ret_host_url(hub_id) <> @ret_internal_scope <> @change_email_for_login,


### PR DESCRIPTION
What
The Dashboard backend was throwing `(CaseClauseError)` in the hackney module. Traced to the HTTPoison patch request in RetClient. It was because the struct being passed into the PATCH request was not a json so hackney was trying to pattern match the struct (the PATCH request body).

This PR encodes the body and adds headers with application/json.

We still need to figure out why this request is returning a 404 on the Reticulum side.