### PR TITLE
Fix intermittent test failures

### DIFF
--- a/test/dash/account_test.exs
+++ b/test/dash/account_test.exs
@@ -1,7 +1,8 @@
 defmodule Dash.AccountTest do
   use ExUnit.Case
   use Dash.DataCase
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
 
   setup_all do
     setup_http_mocks()

--- a/test/dash/app_config_test.exs
+++ b/test/dash/app_config_test.exs
@@ -1,11 +1,13 @@
 defmodule Dash.AppConfigTest do
   use ExUnit.Case
 
+  import Dash.TestHelpers, only: [merge_module_config: 3]
+
   test "should define cluster correctly" do
-    Application.put_env(:dash, Dash.AppConfig, host: "dashboard.cluster.domain.com")
+    merge_module_config(:dash, Dash.AppConfig, host: "dashboard.cluster.domain.com")
     assert Dash.AppConfig.cluster_domain() === "cluster.domain.com"
 
-    Application.put_env(:dash, Dash.AppConfig, host: "dashboard.domain.com")
+    merge_module_config(:dash, Dash.AppConfig, host: "dashboard.domain.com")
     assert Dash.AppConfig.cluster_domain() === "domain.com"
   end
 end

--- a/test/dash/capability_test.exs
+++ b/test/dash/capability_test.exs
@@ -1,8 +1,8 @@
 defmodule Dash.CapabilityTest do
   use Dash.DataCase
 
+  import Dash.TestHelpers
   import Ecto.Query
-  import DashWeb.TestHelpers
   alias Dash.{Repo, Account}
   require Logger
 

--- a/test/dash/dash_test.exs
+++ b/test/dash/dash_test.exs
@@ -1,7 +1,7 @@
 defmodule Dash.Test do
   use Dash.DataCase
 
-  import DashWeb.TestHelpers
+  import Dash.TestHelpers
   require Logger
 
   setup_all do

--- a/test/dash/fxa_events_test.exs
+++ b/test/dash/fxa_events_test.exs
@@ -1,7 +1,8 @@
 defmodule Dash.FxaEventsTest do
   use ExUnit.Case
   use Dash.DataCase
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
 
   setup_all do
     setup_http_mocks()

--- a/test/dash/hub_stat_test.exs
+++ b/test/dash/hub_stat_test.exs
@@ -1,7 +1,8 @@
 defmodule Dash.HubStatTest do
   use Dash.DataCase
+
+  import Dash.TestHelpers
   import Ecto.Query
-  import DashWeb.TestHelpers
   import Mox
   require Logger
   alias Dash.{Repo, HubStat}

--- a/test/dash/orch_client_test.exs
+++ b/test/dash/orch_client_test.exs
@@ -1,6 +1,7 @@
 defmodule Dash.OrchClientTest do
   use ExUnit.Case
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
   import Mox, only: [verify_on_exit!: 1]
 
   setup_all context do

--- a/test/dash_web/controllers/api/v1/account_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/account_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule DashWeb.Api.V1.AccountControllerTest do
   use DashWeb.ConnCase
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
 
   describe "Account API" do
     test "should error for unauthorized users", %{conn: conn} do

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule DashWeb.Api.V1.FxaEventsControllerTest do
   use DashWeb.ConnCase
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
   require Logger
 
   # @password_change_struct %{

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule DashWeb.Api.V1.HubControllerTest do
   use DashWeb.ConnCase
   use Retry
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
   import Mox
   import Plug.Conn.Status, only: [code: 1]
   require Logger

--- a/test/dash_web/controllers/api/v1/subscription_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule DashWeb.Api.V1.SubscriptionControllerTest do
   use DashWeb.ConnCase
 
-  import DashWeb.TestHelpers
+  import Dash.TestHelpers
 
   describe "show/2" do
     test "should return values in cookie for subscription current period end and cancel at period end",
@@ -79,7 +79,7 @@ defmodule DashWeb.Api.V1.SubscriptionControllerTest do
       conn: conn
     } do
       previous_value = Application.get_env(:dash, Dash)[:plans]
-      Application.put_env(:dash, Dash, plans: "not-formatted-correctly")
+      merge_module_config(:dash, Dash, plans: "not-formatted-correctly")
 
       in_two_days = in_two_days()
 
@@ -98,7 +98,7 @@ defmodule DashWeb.Api.V1.SubscriptionControllerTest do
                  isCancelled: false
                })
 
-      Application.put_env(:dash, Dash, plans: previous_value)
+      merge_module_config(:dash, Dash, plans: previous_value)
     end
 
     test "should return default values if user is not subscribed", %{conn: conn} do

--- a/test/plugs/approved_email_auth_test.exs
+++ b/test/plugs/approved_email_auth_test.exs
@@ -1,6 +1,7 @@
 defmodule DashWeb.Plugs.ApprovedEmailAuthTest do
   use DashWeb.ConnCase
-  import DashWeb.TestHelpers
+
+  import Dash.TestHelpers
   import Mox
   alias Dash.ApprovedEmail
 
@@ -14,14 +15,14 @@ defmodule DashWeb.Plugs.ApprovedEmailAuthTest do
   describe "ApprovedEmailAuth Plug" do
     setup do
       clear_auth_config()
-      Application.put_env(:dash, Dash.ApprovedEmail, enabled: true)
-      on_exit(fn -> Application.put_env(:dash, Dash.ApprovedEmail, enabled: false) end)
+      merge_module_config(:dash, Dash.ApprovedEmail, enabled: true)
+      on_exit(fn -> merge_module_config(:dash, Dash.ApprovedEmail, enabled: false) end)
     end
 
     @valid_expiration token_expiry: ~N[3000-01-01 00:00:00]
 
     test "ApprovedEmails should not be enabled when disabled", %{conn: conn} do
-      Application.put_env(:dash, Dash.ApprovedEmail, enabled: false)
+      merge_module_config(:dash, Dash.ApprovedEmail, enabled: false)
 
       stub_ret_get()
       expect_orch_post()

--- a/test/plugs/auth_test.exs
+++ b/test/plugs/auth_test.exs
@@ -2,7 +2,7 @@ defmodule DashWeb.Plugs.AuthTest do
   use DashWeb.ConnCase
   use DashWeb, :controller
 
-  import DashWeb.TestHelpers
+  import Dash.TestHelpers
   import Mox
 
   setup_all do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,4 +1,4 @@
-defmodule DashWeb.TestHelpers do
+defmodule Dash.TestHelpers do
   import Phoenix.ConnTest
   require Logger
   require Integer


### PR DESCRIPTION
Why
---
Some tests were using `Application.put_env/3` to change a keyword in the value.  `Application.put_env/3` does not put a keyword into the value but completely replaces the value.

For example this code wipes out the `:subdomain_wait_time` keyword:

```elixir
env = Application.get_env(:dash, Dash)
#=> [plans: "plan_test_1,USD,10", subdomain_wait_time: 0]

Application.put_env(:dash, Dash, plans: env[:plans])
#=> :ok

Application.get_env(:dash, Dash)
#=> [plans: "plan_test_1,USD,10"]
```

Since the tests are run in a different pseudorandom order for each PR, this issue didn’t show up until now.

What
----
Replace calls to `Application.put_env/3` where the value is a keyword list with `merge_module_config/3`