### PR TITLE
Update subdomain_denial.ex

### DIFF
--- a/lib/dash/subdomain_denial.ex
+++ b/lib/dash/subdomain_denial.ex
@@ -25,6 +25,7 @@ defmodule Dash.SubdomainDenial do
     "relay",
     "mdn",
     "demo",
+    "hello",
     "official"
   ]
 


### PR DESCRIPTION
bounty instance is hello.dev.myhubs.net, it was created on the backend, and because subdomain was controlled on dashboard, we've got bounty hunters took over the hello domain using dashboard