### PR TITLE
Use "enabled" instead of true for ENABLE_STARTER_PLAN env variable

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,6 +1,6 @@
 AUTH_SERVER=auth.local
 DASH_ROOT_DOMAIN=localhost:3000
-ENABLE_STARTER_PLAN=true
+ENABLE_STARTER_PLAN=enabled
 ENV=local
 FXA_PAYMENT_URL= https://price.local
 FXA_SERVER=fxa.local

--- a/client/util/featureFlag.ts
+++ b/client/util/featureFlag.ts
@@ -17,5 +17,5 @@ export const prodFeature = (): boolean => {
 };
 
 export const enabledStarterPlan = (): boolean => {
-  return ENABLE_STARTER_PLAN === 'true';
+  return ENABLE_STARTER_PLAN === 'enabled';
 };

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -13,7 +13,7 @@ if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
 end
 
 database_hostname = System.get_env("DB_HOSTNAME", "localhost")
-starter_plan_enabled? = System.get_env("ENABLE_STARTER_PLAN") === "true"
+starter_plan_enabled? = System.get_env("ENABLE_STARTER_PLAN") === "enabled"
 
 config :dash, :starter_plan_enabled?, starter_plan_enabled?
 


### PR DESCRIPTION
Because Kubernetes config recognizes booleans. Use "enabled" string instead of true. 

Why?
I could not save the config file with an updated env variable with a value `true` in Skooner for the dev environment.