### PR TITLE
Make dependency installation more deterministic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !config/config.exs
 !config/prod.exs
 !config/runtime.exs
+!container/conditional-npm-ci
 !container/trapped-mix
 !lib/
 !mix.exs

--- a/bin/init
+++ b/bin/init
@@ -9,10 +9,10 @@ docker-compose -f "$composefile" build server &&
 mutagen-compose -f "$composefile" run --rm server sh -c 'trapped-mix do deps.get, deps.compile, ecto.create' &&
 echo -e ${prefix}Initializing Client$suffix &&
 docker-compose -f "$composefile" build client &&
-mutagen-compose -f "$composefile" run --rm client npm install --no-save &&
+mutagen-compose -f "$composefile" run --rm client conditional-npm-ci &&
 echo -e ${prefix}Initializing Marketing$suffix &&
 docker-compose -f "$composefile" build marketing &&
-mutagen-compose -f "$composefile" run --rm marketing npm install --no-save
+mutagen-compose -f "$composefile" run --rm marketing conditional-npm-ci
 
 code=$?
 mutagen-compose down

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,6 +4,7 @@ ARG NODE_VERSION=18
 FROM node:$NODE_VERSION-alpine AS base
 # ---- dev stage ----
 FROM base AS dev
+COPY container/conditional-npm-ci /usr/local/bin/conditional-npm-ci
 # ---- build stage ----
 FROM base AS builder
 arg GITHUB_TOKEN

--- a/container/conditional-npm-ci
+++ b/container/conditional-npm-ci
@@ -1,0 +1,7 @@
+#!/bin/sh
+checksum='package-lock.sha512'
+
+if ! sha512sum -cs $checksum; then
+  npm ci
+  sha512sum package-lock.json > $checksum
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.9"
 services:
   client:
     build:
-      context: ./client
+      context: .
+      dockerfile: client/Dockerfile
       target: dev
     command: npm run dev
     environment:
@@ -25,7 +26,8 @@ services:
       - pgdata:/var/lib/postgresql/data
   marketing:
     build:
-      context: ./marketing
+      context: .
+      dockerfile: marketing/Dockerfile
       target: dev
     command: npm run dev
     environment:
@@ -66,6 +68,7 @@ x-mutagen:
           - ".gitignore"
           - "Dockerfile"
           - "docker-compose.yml"
+          - "package-lock.sha512"
           - "/bin/"
         vcs: true
       mode: "two-way-resolved"

--- a/marketing/Dockerfile
+++ b/marketing/Dockerfile
@@ -4,6 +4,7 @@ ARG NODE_VERSION=18
 FROM node:$NODE_VERSION-alpine AS base
 # ---- dev stage ----
 FROM base AS dev
+COPY container/conditional-npm-ci /usr/local/bin/conditional-npm-ci
 # ---- build stage ----
 FROM base AS builder
 arg GITHUB_TOKEN


### PR DESCRIPTION
Why
---
Although `npm install --no-save` doesn’t alter `package-lock.json`, it doesn’t honor `package-lock.json` any more than `npm install`.  The clean install `npm ci` is time-consuming and should only be run if `package-lock.json` has changed.

How
---
* Create `conditional-npm-ci`
* Use `conditional-npm-ci` for client and marketing page