### PR TITLE
Update dark theme menu color to white to contrast with darker text

### DIFF
--- a/client/styles/core/theme.scss
+++ b/client/styles/core/theme.scss
@@ -201,7 +201,7 @@ main[data-theme='dark'] {
   /**
   MENU
   **/
-  --color-interactions-menu: #000000;
+  --color-interactions-menu: #ffffff;
   --color-interactions-menu-hover: #2f2f2f;
   --color-interactions-menu-inactive: #757575;
 }

--- a/marketing/styles/globals.scss
+++ b/marketing/styles/globals.scss
@@ -242,7 +242,7 @@ main[data-theme='dark'] {
   /**
   MENU
   **/
-  --color-interactions-menu: #000000;
+  --color-interactions-menu: #ffffff;
   --color-interactions-menu-hover: #2f2f2f;
   --color-interactions-menu-inactive: #757575;
 }


### PR DESCRIPTION
Noticed with dark theme the tool tip component appears as black text on a black background. Updated the corresponding variable to reflect Lilypad appearance.