### PR TITLE
Read the Sentry environment name from the environment

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -79,9 +79,6 @@ config :sentry,
   # access to any information.
   dsn: "https://0688486cc05c4c2e977393eb607bb390@o1069899.ingest.sentry.io/4505037614678016",
   enable_source_code_context: true,
-  environment_name: :prod,
-  included_environments: [:prod],
-  root_source_code_path: File.cwd!(),
-  tags: %{
-    env: "production"
-  }
+  environment_name: System.get_env("ENVIRONMENT_NAME", "unnamed"),
+  included_environments: ["production", "staging"],
+  root_source_code_path: File.cwd!()


### PR DESCRIPTION
This will allow us to distinguish between exceptions from **dashboard.dev.myhubs.net** and **dashboard.myhubs.net**. I’ve set `ENVIRONMENT_NAME` for the deployment in both clusters.