### PR TITLE
Fix perpetual paid plan

### DIFF
--- a/lib/dash_web/fxa_events.ex
+++ b/lib/dash_web/fxa_events.ex
@@ -95,7 +95,7 @@ defmodule DashWeb.FxaEvents do
     else
       Dash.delete_all_hubs_for_account(account)
       # This is a temporary solution to prevent Standard plan features from
-      # remaining in effect after subscription expiration.  It will be replace
+      # remaining in effect after subscription expiration.  It can be replaced
       # when the “stop” FSM event is implemented.
       Dash.Repo.delete_all(from p in Dash.Plan, where: p.account_id == ^account.account_id)
     end


### PR DESCRIPTION
Why
---
If a subscription expires before the Starter Plan is released, the subscriber will continue to enjoy the benefits of a paid plan.

Though we mirror the capability creation in the plan model, we don’t mirror the capability deactivation.  This fixes that.

What
----
* Remove plan when subscription expires

Note
----
This PR should be merged before deploying https://github.com/mozilla/turkey-portal/pull/289 into production.