### PR TITLE
Fix Sentry environment name

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -72,13 +72,3 @@ config :dash, Dash.Scheduler,
     # Runs every midnight:
     {"@daily", {Dash.HubStat, :job_record_hub_stats, []}}
   ]
-
-config :sentry,
-  # Data Source Names (DSN) are safe to keep public because they only allow
-  # submission of new events and related event data; they do not allow read
-  # access to any information.
-  dsn: "https://0688486cc05c4c2e977393eb607bb390@o1069899.ingest.sentry.io/4505037614678016",
-  enable_source_code_context: true,
-  environment_name: System.get_env("ENVIRONMENT_NAME", "unnamed"),
-  included_environments: ["production", "staging"],
-  root_source_code_path: File.cwd!()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -103,6 +103,16 @@ case config_env() do
       plans: System.fetch_env!("PLANS"),
       subdomain_wait_time: 15000
 
+    config :sentry,
+      # Data Source Names (DSN) are safe to keep public because they only allow
+      # submission of new events and related event data; they do not allow read
+      # access to any information.
+      dsn: "https://0688486cc05c4c2e977393eb607bb390@o1069899.ingest.sentry.io/4505037614678016",
+      enable_source_code_context: true,
+      environment_name: System.get_env("ENVIRONMENT_NAME", "unnamed"),
+      included_environments: ["production", "staging"],
+      root_source_code_path: File.cwd!()
+
     # ## Using releases
     #
     # If you are doing OTP releases, you need to instruct Phoenix


### PR DESCRIPTION
Why
---
The environment name used by Sentry cannot be set by an environment variable on the instance.  This is because the variable is read at compile time instead of runtime.

What
----
* Move Sentry configuration to `runtime.exs`

Side Effects
------------
The `sentry.send_test_event` task will have to be prefaced by `app.config` in order to pick up the runtime configuration: `mix do app.config, sentry.send_test_event`.