### PR TITLE
Fix CSRF vulnerability

### DIFF
--- a/lib/dash_web/endpoint.ex
+++ b/lib/dash_web/endpoint.ex
@@ -48,7 +48,7 @@ defmodule DashWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
+    parsers: [:urlencoded, :json],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 

--- a/lib/dash_web/plugs/content_type_restriction.ex
+++ b/lib/dash_web/plugs/content_type_restriction.ex
@@ -1,0 +1,42 @@
+defmodule DashWeb.ContentTypeRestriction do
+  @moduledoc """
+  Plug to restrict the content-types of requests.
+
+  This can be used to prevent cross-site request forgery (CSRF) on JSON-only
+  routes, subjecting all requests to the browser-enforced same-origin policy
+  (SOP).
+
+  ## Examples
+
+      plug DashWeb.ContentTypeRestriction, ["application/json", "application/vnd.api+json"]
+
+  """
+  @behaviour Plug
+  @unprotected_methods ~w(HEAD GET OPTIONS)
+
+  @impl Plug
+  def init(allowed_types) when is_list(allowed_types),
+    do: allowed_types
+
+  @impl Plug
+  def call(%Plug.Conn{} = conn, allowed_types) when is_list(allowed_types) do
+    if conn.method in @unprotected_methods or content_type(conn) in allowed_types do
+      conn
+    else
+      conn
+      |> Plug.Conn.send_resp(415, "Unsupported Media Type")
+      |> Plug.Conn.halt()
+    end
+  end
+
+  @spec content_type(Plug.Conn.t()) :: String.t()
+  defp content_type(%Plug.Conn{} = conn) do
+    case Plug.Conn.get_req_header(conn, "content-type") do
+      [] ->
+        "text/plain"
+
+      [content_type] ->
+        content_type
+    end
+  end
+end

--- a/lib/dash_web/router.ex
+++ b/lib/dash_web/router.ex
@@ -11,6 +11,7 @@ defmodule DashWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug DashWeb.ContentTypeRestriction, ["application/json"]
   end
 
   pipeline :jwt_authenticated do
@@ -51,7 +52,7 @@ defmodule DashWeb.Router do
   end
 
   scope "/api/v1", DashWeb do
-    pipe_through [:basic_auth, :jwt_authenticated]
+    pipe_through [:api, :basic_auth, :jwt_authenticated]
 
     resources "/account", Api.V1.AccountController, only: [:show], singleton: true
     resources "/plans", Api.V1.PlanController, only: [:create]
@@ -59,7 +60,7 @@ defmodule DashWeb.Router do
   end
 
   scope "/api/v1", DashWeb do
-    pipe_through [:basic_auth, :jwt_authenticated, :approved_email_auth]
+    pipe_through [:api, :basic_auth, :jwt_authenticated, :approved_email_auth]
 
     resources "/hubs",
               Api.V1.HubController,
@@ -72,7 +73,7 @@ defmodule DashWeb.Router do
   end
 
   scope "/api/v1", DashWeb do
-    pipe_through :fxa_events_parser
+    pipe_through [:api, :fxa_events_parser]
     # TODO decode JWT tokens from FxA with a new plug
     resources "/events/fxa", Api.V1.FxaEventsController, [:create]
   end

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -39,6 +39,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       conn
       |> put_resp_content_type("application/json")
       |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+      |> put_req_header("content-type", "application/json")
       |> post("/api/v1/events/fxa")
 
       # time set for auth_changed_at
@@ -66,6 +67,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       conn
       |> put_resp_content_type("application/json")
       |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+      |> put_req_header("content-type", "application/json")
       |> post("/api/v1/events/fxa")
 
       account_after = get_test_account()
@@ -97,6 +99,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -120,6 +123,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
     end
@@ -136,6 +140,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -161,6 +166,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
           conn
           |> put_resp_content_type("application/json")
           |> put_req_header("authorization", "Bearer #{token}")
+          |> put_req_header("content-type", "application/json")
           |> post("/api/v1/events/fxa")
         end
       end
@@ -181,6 +187,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
         conn
         |> put_resp_content_type("application/json")
         |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+        |> put_req_header("content-type", "application/json")
         |> post("/api/v1/events/fxa")
 
       assert response(conn, 200)
@@ -204,6 +211,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -232,6 +240,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -253,6 +262,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -271,6 +281,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -286,6 +297,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -304,6 +316,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -323,6 +336,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
+             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 

--- a/test/dash_web/controllers/api/v1/plan_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/plan_controller_test.exs
@@ -21,6 +21,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
       assert "Not Found" ===
                conn
                |> put_test_token(claims: %{"fxa_subscriptions" => []}, token_expiry: tomorrow())
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> response(404)
     end
@@ -31,6 +32,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
       assert %{"status" => "created"} ===
                conn
                |> put_test_token(claims: %{"fxa_subscriptions" => []}, token_expiry: tomorrow())
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> json_response(201)
     end
@@ -44,6 +46,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
                  claims: %{"fxa_subscriptions" => [capability_string()]},
                  token_expiry: tomorrow()
                )
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> json_response(409)
     end
@@ -51,6 +54,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
     test "when the user is not authorized", %{conn: conn} do
       assert @unauthorized_redirect ===
                conn
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> response(401)
     end
@@ -59,6 +63,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
       assert @unauthorized_redirect ===
                conn
                |> put_test_token(token_expiry: tomorrow(), unverified: true)
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> response(401)
     end
@@ -67,6 +72,7 @@ defmodule DashWeb.Api.V1.PlanControllerTest do
       assert @unauthorized_redirect ===
                conn
                |> put_test_token(token_expiry: ~N[1970-01-01 00:00:00])
+               |> put_req_header("content-type", "application/json")
                |> post(@route, tier: "starter")
                |> response(401)
     end


### PR DESCRIPTION
Why
---
Browser routes are protected from cross-site request forgery (CSRF), but an attacker can ride any user’s session and perform any action on their behalf via API routes.  The server ignores the request content-type allowing an attacker to bypass the same-origin policy (SOP) using form data.

What
----
* Restrict API payload content-type to `application/json`
* Remove needless multipart parsing

Side Effects
------------
Any calls to the API will need to provide the `application/json` content-type header.