### PR TITLE
Use SameSite cookie attribute

### DIFF
--- a/client/services/routeGuard.service.ts
+++ b/client/services/routeGuard.service.ts
@@ -43,6 +43,7 @@ function didSetTurkeyauthCookie(context: GetServerSidePropsContext): boolean {
     req,
     res,
     maxAge: 3600 * cookieTtlHours,
+    sameSite: 'lax',
   });
 
   // Note: the 'setCookie' above does not set cookie in time to be used in the

--- a/lib/dash_web/plugs/auth.ex
+++ b/lib/dash_web/plugs/auth.ex
@@ -170,11 +170,12 @@ defmodule DashWeb.Plugs.Auth do
       conn,
       @cookie_name,
       "",
-      path: "/",
       domain: cookie_domain,
       http_only: true,
-      secure: cookie_secure,
-      max_age: 0
+      max_age: 0,
+      path: "/",
+      same_site: "lax",
+      secure: cookie_secure
     )
 
     if cookie_domain =~ "dev.myhubs.net", do: clear_dev_cookie(conn), else: conn
@@ -187,11 +188,12 @@ defmodule DashWeb.Plugs.Auth do
       conn,
       @cookie_name,
       "",
-      path: "/",
       domain: ".dev.myhubs.net",
       http_only: true,
-      secure: cookie_secure,
-      max_age: 0
+      max_age: 0,
+      path: "/",
+      same_site: "lax",
+      secure: cookie_secure
     )
   end
 end


### PR DESCRIPTION
This is an additional CSRF mitigation. I verified with @tanfarming that this will not impact Skooner login or other services in the dev environment.