### PR TITLE
Block spiders

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Why
---
We don’t want the dashboard to be indexed by search engines.

Spiders are hitting the dashboard with incorrect headers.  This is yielding exceptions.

What
----
* Add robots.txt