### PR TITLE
Hotfix - remove content type restriction from FxA webhook

### DIFF
--- a/lib/dash_web/router.ex
+++ b/lib/dash_web/router.ex
@@ -73,7 +73,7 @@ defmodule DashWeb.Router do
   end
 
   scope "/api/v1", DashWeb do
-    pipe_through [:api, :fxa_events_parser]
+    pipe_through :fxa_events_parser
     # TODO decode JWT tokens from FxA with a new plug
     resources "/events/fxa", Api.V1.FxaEventsController, [:create]
   end

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -39,7 +39,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       conn
       |> put_resp_content_type("application/json")
       |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-      |> put_req_header("content-type", "application/json")
       |> post("/api/v1/events/fxa")
 
       # time set for auth_changed_at
@@ -67,7 +66,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       conn
       |> put_resp_content_type("application/json")
       |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-      |> put_req_header("content-type", "application/json")
       |> post("/api/v1/events/fxa")
 
       account_after = get_test_account()
@@ -99,7 +97,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -123,7 +120,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
     end
@@ -140,7 +136,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -166,7 +161,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
           conn
           |> put_resp_content_type("application/json")
           |> put_req_header("authorization", "Bearer #{token}")
-          |> put_req_header("content-type", "application/json")
           |> post("/api/v1/events/fxa")
         end
       end
@@ -187,7 +181,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
         conn
         |> put_resp_content_type("application/json")
         |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-        |> put_req_header("content-type", "application/json")
         |> post("/api/v1/events/fxa")
 
       assert response(conn, 200)
@@ -211,7 +204,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -240,7 +232,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -262,7 +253,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -281,7 +271,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -297,7 +286,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -316,7 +304,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 
@@ -336,7 +323,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{Jason.encode!(body)}")
-             |> put_req_header("content-type", "application/json")
              |> post("/api/v1/events/fxa")
              |> response(200)
 


### PR DESCRIPTION
This removes the content-type restriction for the fxa webhook.

Why?
On the dev environment, the backend was returning response code 415 to fxa webhook events. Because the FxA webhook is on a retry loop until it gets a 200, I'm merging this hotfix.

Side effect of PR: https://github.com/mozilla/turkey-portal/pull/307

<img width="692" alt="image" src="https://user-images.githubusercontent.com/29560735/236592549-2a02a3dc-a288-45d8-aa3f-ac19c232d755.png">
