### PR TITLE
Hotfix margin-bottom

### DIFF
--- a/client/components/cards/SubCard/SubCard.module.scss
+++ b/client/components/cards/SubCard/SubCard.module.scss
@@ -6,6 +6,7 @@
   padding: 24px;
   width: 487px;
   border-radius: 20px;
+  margin-bottom: 24px;
 
   @include desktop-large-down {
     width: 100%;
@@ -13,6 +14,7 @@
   }
 
   @include mobile-down {
+    margin-bottom: 0px;
     border-radius: 0;
   }
 }


### PR DESCRIPTION
When having an EA plan, the SubCard components didn't have any margin bottom for larger than mobile screens and was touching the element below it. 

This fixes that bug. 