### PR TITLE
Use new tier codes

### DIFF
--- a/client/components/cards/HubCard/HubCardFooter.tsx
+++ b/client/components/cards/HubCard/HubCardFooter.tsx
@@ -36,6 +36,8 @@ const FormattedTierMap: FormattedTierMapT = {
   mvp: 'Mvp',
   free: 'Starter',
   premium: 'Premium',
+  p0: 'Starter',
+  p1: 'Early Access',
 };
 
 const HubCardFooter = ({ hub, classProp = '' }: HubCardFooterPropsT) => {

--- a/client/types/General.ts
+++ b/client/types/General.ts
@@ -3,7 +3,7 @@
  * Note: feel free to break-out into other files if you feel the need
  */
 
-export type TierT = 'mvp' | 'free' | 'early_access' | 'premium';
+export type TierT = 'mvp' | 'free' | 'early_access' | 'premium' | 'p0' | 'p1';
 export type FormattedTierT = 'Mvp' | 'Starter' | 'Early Access' | 'Premium';
 
 export type FormattedTierMapT = {

--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -15,7 +15,7 @@ defmodule Dash.Hub do
     field :status, Ecto.Enum, values: [:creating, :updating, :ready, :subdomain_error, :error]
     field :storage_limit_mb, :integer
     field :subdomain, :string
-    field :tier, Ecto.Enum, values: [:free, :mvp, :early_access]
+    field :tier, Ecto.Enum, values: [:free, :mvp, :early_access, :p0, :p1]
     belongs_to :account, Dash.Account, references: :account_id
 
     timestamps()
@@ -119,7 +119,7 @@ defmodule Dash.Hub do
 
   @hub_defaults %{
     name: "Untitled Hub",
-    tier: :early_access,
+    tier: :p1,
     ccu_limit: 25,
     storage_limit_mb: 2000
   }

--- a/lib/dash/plan_state_machine.ex
+++ b/lib/dash/plan_state_machine.ex
@@ -91,7 +91,7 @@ defmodule Dash.PlanStateMachine do
         status: :creating,
         storage_limit_mb: @starter_storage_limit_mb,
         subdomain: rand_string(10),
-        tier: :free
+        tier: :p0
       })
 
     {:ok, %{status_code: 200}} = OrchClient.create_hub(account.email, hub)
@@ -115,7 +115,7 @@ defmodule Dash.PlanStateMachine do
         status: :creating,
         storage_limit_mb: @standard_storage_limit_mb,
         subdomain: rand_string(10),
-        tier: :early_access
+        tier: :p1
       })
 
     {:ok, %{status_code: 200}} = OrchClient.create_hub(account.email, hub)
@@ -146,7 +146,7 @@ defmodule Dash.PlanStateMachine do
       |> Ecto.Changeset.change(
         ccu_limit: @standard_ccu_limit,
         storage_limit_mb: @standard_storage_limit_mb,
-        tier: :early_access
+        tier: :p1
       )
       |> Repo.update!()
       |> OrchClient.update_tier()
@@ -203,7 +203,7 @@ defmodule Dash.PlanStateMachine do
           ccu_limit: @starter_ccu_limit,
           storage_limit_mb: @starter_storage_limit_mb,
           subdomain: rand_string(10),
-          tier: :free
+          tier: :p0
         )
         |> Repo.update!()
 

--- a/test/dash/plan_state_machine_test.exs
+++ b/test/dash/plan_state_machine_test.exs
@@ -98,7 +98,7 @@ defmodule Dash.PlanStateMachineTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "free" === payload["tier"]
+        assert "p0" === payload["tier"]
         assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
@@ -109,7 +109,7 @@ defmodule Dash.PlanStateMachineTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 10 === hub.ccu_limit
       assert 500 === hub.storage_limit_mb
-      assert :free === hub.tier
+      assert :p0 === hub.tier
 
       assert [plan] = Repo.all(Plan)
       assert account.account_id === plan.account_id
@@ -131,7 +131,7 @@ defmodule Dash.PlanStateMachineTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "early_access" === payload["tier"]
+        assert "p1" === payload["tier"]
         assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
@@ -148,7 +148,7 @@ defmodule Dash.PlanStateMachineTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 25 === hub.ccu_limit
       assert 2_000 === hub.storage_limit_mb
-      assert :early_access === hub.tier
+      assert :p1 === hub.tier
 
       assert [plan] = Repo.all(Plan)
       assert account.account_id === plan.account_id
@@ -209,7 +209,7 @@ defmodule Dash.PlanStateMachineTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "early_access" === payload["tier"]
+        assert "p1" === payload["tier"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -226,7 +226,7 @@ defmodule Dash.PlanStateMachineTest do
       assert 25 === hub.ccu_limit
       assert hub_id === hub.hub_id
       assert 2_000 === hub.storage_limit_mb
-      assert :early_access === hub.tier
+      assert :p1 === hub.tier
 
       assert [plan] = Repo.all(Plan)
       assert account.account_id === plan.account_id
@@ -304,7 +304,7 @@ defmodule Dash.PlanStateMachineTest do
         assert Integer.to_string(hub_id) === payload["hub_id"]
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "free" === payload["tier"]
+        assert "p0" === payload["tier"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -322,7 +322,7 @@ defmodule Dash.PlanStateMachineTest do
       assert hub_id === hub.hub_id
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
-      assert :free === hub.tier
+      assert :p0 === hub.tier
 
       assert [plan] = Repo.all(Plan)
       assert account.account_id === plan.account_id

--- a/test/dash_test.exs
+++ b/test/dash_test.exs
@@ -218,7 +218,7 @@ defmodule DashTest do
         assert Integer.to_string(hub_id) === payload["hub_id"]
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "free" === payload["tier"]
+        assert "p0" === payload["tier"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -230,7 +230,7 @@ defmodule DashTest do
       assert hub_id === hub.hub_id
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
-      assert :free === hub.tier
+      assert :p0 === hub.tier
     end
 
     test "when the account has an active subscription plan (DEPRECATED capability)", %{
@@ -255,7 +255,7 @@ defmodule DashTest do
           status: :creating,
           storage_limit_mb: 2_000,
           subdomain: custom_subdomain,
-          tier: :early_access
+          tier: :p1
         })
         |> Ecto.Changeset.change(subdomain: custom_subdomain)
         |> Repo.update!()
@@ -269,7 +269,7 @@ defmodule DashTest do
         assert Integer.to_string(hub_id) === payload["hub_id"]
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "free" === payload["tier"]
+        assert "p0" === payload["tier"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -281,7 +281,7 @@ defmodule DashTest do
       assert hub_id === hub.hub_id
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
-      assert :free === hub.tier
+      assert :p0 === hub.tier
     end
 
     test "with expired_at earlier than the last state transition, when the account has an active subscription plan",
@@ -302,7 +302,7 @@ defmodule DashTest do
       assert 10 !== hub.ccu_limit
       assert 500 !== hub.storage_limit_mb
       assert custom_subdomain === hub.subdomain
-      assert :free !== hub.tier
+      assert :p0 !== hub.tier
     end
   end
 
@@ -394,7 +394,7 @@ defmodule DashTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "free" === payload["tier"]
+        assert "p0" === payload["tier"]
         assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
@@ -405,7 +405,7 @@ defmodule DashTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 10 === hub.ccu_limit
       assert 500 === hub.storage_limit_mb
-      assert :free === hub.tier
+      assert :p0 === hub.tier
     end
 
     @tag :skip
@@ -460,7 +460,7 @@ defmodule DashTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "early_access" === payload["tier"]
+        assert "p1" === payload["tier"]
         assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
@@ -471,7 +471,7 @@ defmodule DashTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 25 === hub.ccu_limit
       assert 2_000 === hub.storage_limit_mb
-      assert :early_access === hub.tier
+      assert :p1 === hub.tier
     end
 
     @tag :skip
@@ -496,7 +496,7 @@ defmodule DashTest do
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
-        assert "early_access" === payload["tier"]
+        assert "p1" === payload["tier"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -509,7 +509,7 @@ defmodule DashTest do
       assert 25 === hub.ccu_limit
       assert hub_id === hub.hub_id
       assert 2_000 === hub.storage_limit_mb
-      assert :early_access === hub.tier
+      assert :p1 === hub.tier
     end
   end
 


### PR DESCRIPTION
Why
---
Orchestrator ignores the `free` and `early_access` tier codes

What
----
* Use `p0` instead of `free` for hubs under the starter plan
* Use `p1` instead of `early_access` for hubs under the standard plan