### PR TITLE
hotfix - If fpn-browser capability return 200

### DIFF
--- a/lib/dash_web/fxa_events.ex
+++ b/lib/dash_web/fxa_events.ex
@@ -110,7 +110,7 @@ defmodule DashWeb.FxaEvents do
         # This is a temporary solution to prevent Standard plan features from
         # remaining in effect after subscription expiration.  It can be replaced
         # when the “stop” FSM event is implemented.
-        Dash.Repo.delete_all(from(p in Dash.Plan, where: p.account_id == ^account.account_id))
+        Dash.Repo.delete_all(from p in Dash.Plan, where: p.account_id == ^account.account_id)
       end
     end
 


### PR DESCRIPTION
Issue:
Subplat had a configuration issue where "fpn-browser" subscription change events are to be sent to all RPs. Because Dashboard did not recognize this, the Dashboard is returning 500 to the webhook requests.

Subplat fixed the issue on their end. We need to silence the retries on the webhook.