### PR TITLE
Fix skeleton loading on upgrade/downgrade

### DIFF
--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -3,7 +3,7 @@ defmodule Dash.Hub do
   import Ecto.Query
   import Ecto.Changeset
   require Logger
-  alias Dash.{Account, Repo, RetClient, SubdomainDenial}
+  alias Dash.{Repo, RetClient, SubdomainDenial}
 
   @type t :: %__MODULE__{}
 
@@ -97,7 +97,7 @@ defmodule Dash.Hub do
     if has_subscription? and not has_hubs(account), do: create_default_hub(account, email)
 
     # TODO EA make own hub controller endpoint for waiting_until_ready_state
-    if has_creating_hubs(account) or updating_hub?(account) do
+    if has_creating_hubs(account) do
       [hub] = hubs_for_account(account)
 
       case RetClient.wait_until_healthy(hub) do
@@ -112,15 +112,6 @@ defmodule Dash.Hub do
       {:ok}
     end
   end
-
-  @spec updating_hub?(Account.t()) :: boolean
-  defp updating_hub?(%Account{account_id: account_id}),
-    do:
-      Repo.exists?(
-        from h in Dash.Hub,
-          where: h.account_id == ^account_id,
-          where: h.status == :updating
-      )
 
   @hub_defaults %{
     name: "Untitled Hub",

--- a/test/dash/plan_state_machine_test.exs
+++ b/test/dash/plan_state_machine_test.exs
@@ -220,6 +220,14 @@ defmodule Dash.PlanStateMachineTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert :ok ===
                PlanStateMachine.handle_event(
                  :starter,
@@ -231,7 +239,7 @@ defmodule Dash.PlanStateMachineTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 25 === hub.ccu_limit
       assert hub_id === hub.hub_id
-      assert :updating === hub.status
+      assert :ready === hub.status
       assert 2_000 === hub.storage_limit_mb
       assert :p1 === hub.tier
 
@@ -318,6 +326,14 @@ defmodule Dash.PlanStateMachineTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert :ok ===
                PlanStateMachine.handle_event(
                  :standard,
@@ -329,7 +345,7 @@ defmodule Dash.PlanStateMachineTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 10 === hub.ccu_limit
       assert hub_id === hub.hub_id
-      assert :updating === hub.status
+      assert :ready === hub.status
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
       assert :p0 === hub.tier

--- a/test/dash_test.exs
+++ b/test/dash_test.exs
@@ -225,12 +225,20 @@ defmodule DashTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert :ok === Dash.expire_plan_subscription(account, expired_at)
       assert {:ok, %{subscription?: false}} = Dash.fetch_active_plan(account)
       assert [hub] = Hub.hubs_for_account(account)
       assert 10 === hub.ccu_limit
       assert hub_id === hub.hub_id
-      assert :updating === hub.status
+      assert :ready === hub.status
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
       assert :p0 === hub.tier
@@ -279,12 +287,20 @@ defmodule DashTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert :ok === Dash.expire_plan_subscription(account, expired_at)
       assert {:ok, %{subscription?: false}} = Dash.fetch_active_plan(account)
       assert [hub] = Hub.hubs_for_account(account)
       assert 10 === hub.ccu_limit
       assert hub_id === hub.hub_id
-      assert :updating === hub.status
+      assert :ready === hub.status
       assert 500 === hub.storage_limit_mb
       assert custom_subdomain !== hub.subdomain
       assert :p0 === hub.tier
@@ -514,6 +530,14 @@ defmodule DashTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert :ok === Dash.subscribe_to_standard_plan(account, after_start)
       {:ok, plan} = Dash.fetch_active_plan(account)
       assert plan_id === plan.plan_id
@@ -521,7 +545,7 @@ defmodule DashTest do
       assert [hub] = Hub.hubs_for_account(account)
       assert 25 === hub.ccu_limit
       assert hub_id === hub.hub_id
-      assert :updating === hub.status
+      assert :ready === hub.status
       assert 2_000 === hub.storage_limit_mb
       assert :p1 === hub.tier
     end

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -242,6 +242,14 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
+      Mox.expect(Dash.HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")


### PR DESCRIPTION
Why
---
When an account is upgrading or downgrading the skeleton loader is displayed in place of the upgrading hub message.

What
----
* Set hub to ready as part of the upgrade/downgrade rather than the dashboard load

Side Effects
------------
This will prolong plan state transitions which may have undesirable repercussions.