### PR TITLE
fixing post auth callback url

### DIFF
--- a/client/services/routeGuard.service.ts
+++ b/client/services/routeGuard.service.ts
@@ -65,7 +65,7 @@ function handleUnauthenticatedRedirects(axiosError: AxiosError) {
 
   // If Redirect specified send them to auth
   if (status === 401 && data?.redirect === 'auth') {
-    return redirectToAuthServer();
+    return redirectToAuthServer(RoutesE.CONFIRM_PLAN);
   }
 
   // Unexpected error
@@ -141,6 +141,7 @@ export function pageRequireAuthentication(gssp: Function): GetServerSideProps {
       const account: AccountT = await getAccount(
         req.headers as AxiosRequestHeaders
       );
+
       if (account.hasSubscription || account.hasPlan) {
         return redirectToDashboard();
       }

--- a/client/util/redirects.ts
+++ b/client/util/redirects.ts
@@ -1,38 +1,18 @@
 import { RoutesE } from 'types/Routes';
 import { AUTH_SERVER, DASH_ROOT_DOMAIN, MARKETING_PAGE_URL } from 'config';
 
-/**************************
- *  RE-DIRECT UTILITIES
- **************************/
-
-const redirectConfig = {
-  auth: {
-    source: RoutesE.DASHBOARD,
-    destination: `https://${AUTH_SERVER}/login?idp=fxa&client=https://${DASH_ROOT_DOMAIN}`,
-    permanent: false,
-  },
-  marketing: {
-    source: RoutesE.DASHBOARD,
-    destination: MARKETING_PAGE_URL,
-    permanent: false,
-  },
-  dashboard: {
-    destination: RoutesE.DASHBOARD,
-    permanent: false,
-  },
-  subscription: {
-    source: RoutesE.DASHBOARD,
-    destination: RoutesE.SUBSCRIBE,
-    permanent: false,
-  },
-};
-
 /**
  * To Auth
  * @returns redirect
  */
-export const redirectToAuthServer = () => {
-  return { redirect: redirectConfig.auth };
+export const redirectToAuthServer = (callbackRoute = DASH_ROOT_DOMAIN) => {
+  return {
+    redirect: {
+      source: RoutesE.DASHBOARD,
+      destination: `https://${AUTH_SERVER}/login?idp=fxa&client=https://${callbackRoute}`,
+      permanent: false,
+    },
+  };
 };
 
 /**
@@ -40,7 +20,13 @@ export const redirectToAuthServer = () => {
  * @returns redirect
  */
 export const redirectToMarketingPage = () => {
-  return { redirect: redirectConfig.marketing };
+  return {
+    redirect: {
+      source: RoutesE.DASHBOARD,
+      destination: MARKETING_PAGE_URL,
+      permanent: false,
+    },
+  };
 };
 
 /**
@@ -48,7 +34,12 @@ export const redirectToMarketingPage = () => {
  * @returns redirect
  */
 export const redirectToDashboard = () => {
-  return { redirect: redirectConfig.dashboard };
+  return {
+    redirect: {
+      destination: RoutesE.DASHBOARD,
+      permanent: false,
+    },
+  };
 };
 
 /**
@@ -56,5 +47,11 @@ export const redirectToDashboard = () => {
  * @returns redirect
  */
 export const redirectToSubscribe = () => {
-  return { redirect: redirectConfig.subscription };
+  return {
+    redirect: {
+      source: RoutesE.DASHBOARD,
+      destination: RoutesE.SUBSCRIBE,
+      permanent: false,
+    },
+  };
 };


### PR DESCRIPTION
why

There was no configurable callback url when a user was authenticated so after auth they where always sent back to /dash url. This is not what want on every un-authed user anymore. 