### PR TITLE
Fix skeleton loading on upgrade/downgrade

### DIFF
--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -3,7 +3,7 @@ defmodule Dash.Hub do
   import Ecto.Query
   import Ecto.Changeset
   require Logger
-  alias Dash.{Account, Repo, RetClient, SubdomainDenial}
+  alias Dash.{Repo, RetClient, SubdomainDenial}
 
   @type t :: %__MODULE__{}
 
@@ -95,32 +95,34 @@ defmodule Dash.Hub do
   def ensure_default_hub_is_ready(%Dash.Account{} = account, email, has_subscription?) do
     # Need subscription in order to create hub
     if has_subscription? and not has_hubs(account), do: create_default_hub(account, email)
+    hub = Repo.one(from h in Dash.Hub, where: h.account_id == ^account.account_id)
 
-    # TODO EA make own hub controller endpoint for waiting_until_ready_state
-    if has_creating_hubs(account) or updating_hub?(account) do
-      [hub] = hubs_for_account(account)
+    case hub && hub.status do
+      # TODO EA make own hub controller endpoint for waiting_until_ready_state
+      :creating ->
+        update_hub_status(hub)
 
-      case RetClient.wait_until_healthy(hub) do
-        {:ok} ->
-          set_hub_to_ready(hub)
-          {:ok}
+      :updating ->
+        Task.Supervisor.async(TaskSupervisor, fn -> update_hub_status(hub) end)
+        :ok
 
-        {:error, err} ->
-          {:error, err}
-      end
-    else
-      {:ok}
+      _ ->
+        :ok
     end
   end
 
-  @spec updating_hub?(Account.t()) :: boolean
-  defp updating_hub?(%Account{account_id: account_id}),
-    do:
-      Repo.exists?(
-        from h in Dash.Hub,
-          where: h.account_id == ^account_id,
-          where: h.status == :updating
-      )
+  @spec update_hub_status(Hub.t()) :: :ok | {:error, String.t()}
+  defp update_hub_status(hub) do
+    case RetClient.wait_until_healthy(hub) do
+      {:ok} ->
+        set_hub_to_ready(hub)
+        :ok
+
+      {:error, error} ->
+        Logger.error("Failed to update hub. Hub ID: #{hub.hub_id}. Error: #{inspect(error)}")
+        {:error, error}
+    end
+  end
 
   @hub_defaults %{
     name: "Untitled Hub",

--- a/lib/dash/plan_state_machine.ex
+++ b/lib/dash/plan_state_machine.ex
@@ -154,7 +154,6 @@ defmodule Dash.PlanStateMachine do
       |> Repo.update!()
 
     {:ok, %{status_code: 200}} = OrchClient.update_hub(email, hub)
-
     :ok
   end
 

--- a/lib/dash_web/controllers/api/v1/hub_controller.ex
+++ b/lib/dash_web/controllers/api/v1/hub_controller.ex
@@ -21,11 +21,10 @@ defmodule DashWeb.Api.V1.HubController do
     fxa_account_info = conn.assigns[:fxa_account_info]
     fxa_email = fxa_account_info.fxa_email
     has_subscription? = fxa_account_info.has_subscription?
-
-    Logger.error("HAS SUBSCRIPTION: #{has_subscription?}")
+    Logger.info("HAS SUBSCRIPTION: #{has_subscription?}")
 
     case Hub.ensure_default_hub_is_ready(account, fxa_email, has_subscription?) do
-      {:ok} ->
+      :ok ->
         hubs = Hub.hubs_with_usage_stats_for_account(account)
         conn |> render("index.json", hubs: hubs)
 

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -238,10 +238,6 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
-      Mox.stub(Dash.HttpMock, :delete, fn _url, _headers, _opts ->
-        {:ok, %HTTPoison.Response{status_code: 200}}
-      end)
-
       assert conn
              |> put_resp_content_type("application/json")
              |> put_req_header("authorization", "Bearer #{token}")

--- a/test/dash_web/controllers/api/v1/hub_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/hub_controller_test.exs
@@ -319,6 +319,46 @@ defmodule DashWeb.Api.V1.HubControllerTest do
   end
 
   describe "Hub Ready state tests" do
+    test "when the hub is creating", %{conn: conn} do
+      Mox.stub(Dash.HttpMock, :post, fn _url, _json, _headers, _opts ->
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
+      Mox.expect(Dash.HttpMock, :get, fn url, _headers, opts ->
+        assert String.starts_with?(url, "https://ret.")
+        assert String.ends_with?(url, "/health")
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
+      Mox.expect(Dash.HttpMock, :get, fn url, headers, opts ->
+        assert String.starts_with?(url, "https://ret.")
+        assert String.ends_with?(url, "/api-internal/v1/presence")
+        assert [{"x-ret-dashboard-access-key", _}] = headers
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{body: Jason.encode!(%{count: 42}), status_code: 200}}
+      end)
+
+      Mox.expect(Dash.HttpMock, :get, fn url, headers, opts ->
+        assert String.starts_with?(url, "https://ret.")
+        assert String.ends_with?(url, "/api-internal/v1/storage")
+        assert [{"x-ret-dashboard-access-key", _}] = headers
+        assert [hackney: [:insecure]] === opts
+
+        {:ok, %HTTPoison.Response{body: Jason.encode!(%{storage_mb: 42}), status_code: 200}}
+      end)
+
+      assert conn
+             |> put_test_token()
+             |> get("/api/v1/hubs")
+             |> json_response(:ok)
+
+      assert [hub] = Hub.hubs_for_account(get_test_account())
+      assert :ready === hub.status
+    end
+
     test "should call ret /health endpoint at least 1 time", %{conn: conn} do
       # TODO To refine test make this test call /health endpoint 3 times
       max_expected_calls = 3


### PR DESCRIPTION
Why
---
When an account is upgrading or downgrading the skeleton loader is displayed in place of the upgrading hub message.

What
----
* Asynchronously set hub to ready as part of dashboard load

Note
----
This fixes the aforementioned issue but also brings back the pre-https://github.com/mozilla/turkey-portal/pull/332 ‘Error/2000 MB’.