### PR TITLE
Add useremail field to hub update Orch requests

### DIFF
--- a/lib/dash/orch_client.ex
+++ b/lib/dash/orch_client.ex
@@ -37,7 +37,8 @@ defmodule Dash.OrchClient do
     )
   end
 
-  def update_hub(%Hub{} = hub, opts \\ []) when is_list(opts) do
+  def update_hub(fxa_email, %Hub{} = hub, opts \\ [])
+      when is_binary(fxa_email) and is_list(opts) do
     disable_branding? = Keyword.get(opts, :disable_branding?, false)
     reset_branding? = Keyword.get(opts, :reset_branding?, false)
 
@@ -50,7 +51,8 @@ defmodule Dash.OrchClient do
         reset_branding: reset_branding?,
         storage_limit: Float.to_string(hub.storage_limit_mb / 1024),
         subdomain: hub.subdomain,
-        tier: hub.tier
+        tier: hub.tier,
+        useremail: fxa_email
       }),
       [],
       hackney: [:insecure]

--- a/test/dash/plan_state_machine_test.exs
+++ b/test/dash/plan_state_machine_test.exs
@@ -5,7 +5,8 @@ defmodule Dash.PlanStateMachineTest do
   import Dash.Utils, only: [capability_string: 0]
 
   setup do
-    %{account: Repo.insert!(%Account{})}
+    Mox.verify_on_exit!()
+    %{account: Repo.insert!(%Account{email: "dummy@test.com"})}
   end
 
   describe "handle_event/2" do
@@ -216,6 +217,7 @@ defmodule Dash.PlanStateMachineTest do
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
         assert "p1" === payload["tier"]
+        assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -314,6 +316,7 @@ defmodule Dash.PlanStateMachineTest do
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
         assert "p0" === payload["tier"]
+        assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)

--- a/test/dash_test.exs
+++ b/test/dash_test.exs
@@ -221,6 +221,7 @@ defmodule DashTest do
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
         assert "p0" === payload["tier"]
+        assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -275,6 +276,7 @@ defmodule DashTest do
         assert "0.48828125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
         assert "p0" === payload["tier"]
+        assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -510,6 +512,7 @@ defmodule DashTest do
         assert "1.953125" === payload["storage_limit"]
         assert hub.subdomain === payload["subdomain"]
         assert "p1" === payload["tier"]
+        assert account.email === payload["useremail"]
 
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
@@ -529,7 +532,7 @@ defmodule DashTest do
 
   @spec create_account :: Account.t()
   defp create_account,
-    do: Account.find_or_create_account_for_fxa_uid("dummy UID")
+    do: Account.find_or_create_account_for_fxa_uid("dummy UID", "dummy@test.com")
 
   defp stub_failed_ret_patch_update_email() do
     Mox.stub(HttpMock, :patch, fn url, _body, _headers, _opts ->

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -223,7 +223,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       stub_http_post_200()
       fxa_uid = "dummy-uid"
       the_past = ~U[1970-01-01 00:00:00.000000Z]
-      account = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid)
+      account = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid, "dummy@test.com")
       :ok = Dash.subscribe_to_standard_plan(account, the_past)
 
       token =


### PR DESCRIPTION
Why
---
> right now the orch uses a fallback useremail it stores in k8s that is the original email used to create the hubs instance, this will not work if it's changed or if the user revokes it's admin access in ret 

―@tanfarming 