### PR TITLE
wrong title on standard card

### DIFF
--- a/marketing/components/shared/Subscribe/StandardPlanCard/StandardPlanCard.tsx
+++ b/marketing/components/shared/Subscribe/StandardPlanCard/StandardPlanCard.tsx
@@ -56,7 +56,7 @@ const StandardPlanCard = () => {
 
   return (
     <BasePlanCard
-      title={enabledStarterPlan() ? 'Standard' : 'Early Access Hub'}
+      title="Early Access Hub"
       color="warm"
       price={
         <Price


### PR DESCRIPTION
why

title was going off wrong feature flag. will need to name enable standard plan() when we move into that phase. 