### PR TITLE
Confirm plan routing issue

### DIFF
--- a/client/components/modules/hubs/HubCard/HubCardFooter.tsx
+++ b/client/components/modules/hubs/HubCard/HubCardFooter.tsx
@@ -58,7 +58,7 @@ const HubCardFooter = ({ hub, classProp = '' }: HubCardFooterPropsT) => {
    * @returns num | string
    */
   const round = (num: number | null): number | string => {
-    if (num == null) return 'Error';
+    if (num == null) return 'Configuring';
 
     // TODO - In the future, I guess we'd use i18n routing and useRouter to get the current
     // locale, but for now default to "en-US".

--- a/client/services/routeGuard.service.ts
+++ b/client/services/routeGuard.service.ts
@@ -17,7 +17,6 @@ import { IncomingMessage } from 'http';
 import { setCookies } from 'cookies-next';
 import { localFeature } from '../util/featureFlag';
 import { AccountT } from 'types/General';
-import { DASH_ROOT_DOMAIN } from 'config';
 
 type UnauthenticatedResponseT = {
   status: Number | undefined;
@@ -69,7 +68,7 @@ function handleUnauthenticatedRedirects(
 
   // If Redirect specified send them to auth
   if (status === 401 && data?.redirect === 'auth') {
-    return redirectToAuthServer(`${DASH_ROOT_DOMAIN}${callbackRoute}`);
+    return redirectToAuthServer(callbackRoute);
   }
 
   // Unexpected error

--- a/client/util/redirects.ts
+++ b/client/util/redirects.ts
@@ -1,15 +1,19 @@
 import { RoutesE } from 'types/Routes';
 import { AUTH_SERVER, MARKETING_PAGE_URL } from 'config';
+import { DASH_ROOT_DOMAIN } from 'config';
 
 /**
  * To Auth
+ * @param RoutesE
  * @returns redirect
  */
-export const redirectToAuthServer = (callbackRoute: string) => {
+export const redirectToAuthServer = (callbackRoute: RoutesE | null) => {
   return {
     redirect: {
       source: RoutesE.DASHBOARD,
-      destination: `https://${AUTH_SERVER}/login?idp=fxa&client=https://${callbackRoute}`,
+      /** WARNING : auth server does not just take any ol url as a callback, 
+      it needs to be added to "trustedClients" in turkey ops to work. */
+      destination: `https://${AUTH_SERVER}/login?idp=fxa&client=https://${DASH_ROOT_DOMAIN}${callbackRoute}`,
       permanent: false,
     },
   };


### PR DESCRIPTION
why

The call back url on the auth server was hard coded to the /dashboard. We need this to be specific to where the user is trying to go. For example when the user is trying to go to the /cofirm-plan page they need to go back to that after auth NOT to the /dashboard. 