### PR TITLE
Added context comment

### DIFF
--- a/lib/dash_web/fxa_events.ex
+++ b/lib/dash_web/fxa_events.ex
@@ -106,6 +106,8 @@ defmodule DashWeb.FxaEvents do
       change_time: truncated_datetime
     })
 
+    # We expire the cookie on every subscription changed event because the auth server puts subscription information
+    # on the cookie. Such as when the subscription is expiring or if it isn't.
     Dash.Account.set_auth_updated_at(fxa_uid, truncated_datetime)
     :ok
   end


### PR DESCRIPTION
Because we rely on the Auth Server to handle OAuthentication for us, the Auth server uses the cookie to share information to the dashboard and frontend. 

In the cookie, we share this information in the cookie only:
```
  "fxa_cancel_at_period_end": true,
  "fxa_current_period_end": 1686175949,
  "fxa_plan_id": "price_123",
```
In the above case, my cookie is telling me that I've cancelled my subscription and it will end at that timestamp! 

So if I now update my subscription to active. We currently NEED the Auth server to update the cookie with that new information. 

So unfortunately, currently we can't stop the loop of users logging in all the time... I wrote the comment to reflect that.

<img width="528" alt="image" src="https://github.com/mozilla/turkey-portal/assets/29560735/e9e663d4-e060-4b3e-b484-ba76033bd24e">
