### PR TITLE
Temporary Storage Max Update

### DIFF
--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -128,7 +128,7 @@ defmodule Dash.Hub do
     name: "Untitled Hub",
     tier: :p1,
     ccu_limit: 25,
-    storage_limit_mb: 2000
+    storage_limit_mb: 999999
   }
 
   def create_default_hub(%Dash.Account{} = account, fxa_email) do


### PR DESCRIPTION
Why -

There is currently not a way for users to truly delete assets. Storage is accumulating even after setting the asset to inactive. For a band aid fix we are updating the storage_limit to _a large number_.

In the interim this keep the user from hitting the max and being able to add assets if they hit the limit. Step 2 will be to update all the current uses storage max. 