### PR TITLE
Personal Plan

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,8 @@ import Config
 config :dash,
   ecto_repos: [Dash.Repo]
 
+config :dash, Dash.Repo.Migrations, http_client: Dash.FakeHttpClient
+
 # Configures the endpoint
 config :dash, DashWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -50,6 +50,8 @@ config :logger, level: :info
 
 config :dash, Dash.OrchClient, orch_host: "turkeyorch:889"
 
+config :dash, Dash.Repo.Migrations, http_client: :hackney
+
 config :dash, Dash.RetClient,
   timeout_ms: 600_000,
   wait_ms: 2000

--- a/lib/dash.ex
+++ b/lib/dash.ex
@@ -52,17 +52,17 @@ defmodule Dash do
     do: PlanStateMachine.handle_event(:start, account)
 
   @doc """
-  Subscribes the given `account` to a standard plan.
+  Subscribes the given `account` to a personal plan.
 
-  This converts an existing plan to a standard plan or creates one if none
+  This converts an existing plan to a personal plan or creates one if none
   exists.
 
   Returns `:ok` if successful.  Otherwise, `{:error, reason}` is returned.
   """
-  @spec subscribe_to_standard_plan(Account.t(), DateTime.t()) ::
+  @spec subscribe_to_personal_plan(Account.t(), DateTime.t()) ::
           :ok | {:error, :account_not_found | :already_started}
-  def subscribe_to_standard_plan(%Account{} = account, %DateTime{} = subscribed_at),
-    do: PlanStateMachine.handle_event({:subscribe_standard, subscribed_at}, account)
+  def subscribe_to_personal_plan(%Account{} = account, %DateTime{} = subscribed_at),
+    do: PlanStateMachine.handle_event({:subscribe_personal, subscribed_at}, account)
 
   def update_or_create_capability_for_changeset(
         %{

--- a/lib/dash/fake_http_client.ex
+++ b/lib/dash/fake_http_client.ex
@@ -1,0 +1,9 @@
+defmodule Dash.FakeHttpClient do
+  @moduledoc false
+
+  def patch(url, headers, payload, opts)
+      when is_binary(url) and is_list(headers) and is_binary(payload) and is_list(opts) do
+    IO.puts([IO.ANSI.cyan(), "PATCH ", url, " ", payload])
+    {:ok, 200, [], ""}
+  end
+end

--- a/lib/dash/hub.ex
+++ b/lib/dash/hub.ex
@@ -10,8 +10,8 @@ defmodule Dash.Hub do
   @type id :: pos_integer
   @type t :: %__MODULE__{account_id: id}
 
-  @standard_ccu_limit 25
-  @standard_storage_limit_mb 2_000
+  @personal_ccu_limit 20
+  @personal_storage_limit_mb 2_000
 
   @primary_key {:hub_id, :id, autogenerate: true}
   schema "hubs" do
@@ -140,9 +140,9 @@ defmodule Dash.Hub do
     hub =
       Repo.insert!(%__MODULE__{
         account_id: account.account_id,
-        ccu_limit: @standard_ccu_limit,
+        ccu_limit: @personal_ccu_limit,
         status: :creating,
-        storage_limit_mb: @standard_storage_limit_mb,
+        storage_limit_mb: @personal_storage_limit_mb,
         subdomain: rand_string(10),
         tier: :p1
       })

--- a/lib/dash/plan_state_machine/plan_transition.ex
+++ b/lib/dash/plan_state_machine/plan_transition.ex
@@ -12,7 +12,7 @@ defmodule Dash.PlanStateMachine.PlanTransition do
   @primary_key {:plan_transition_id, :id, autogenerate: true}
   schema "plan_transitions" do
     field :event, :string
-    field :new_state, Ecto.Enum, values: [:stopped, :starter, :standard, :pro]
+    field :new_state, Ecto.Enum, values: [:stopped, :starter, :personal, :pro]
     field :transitioned_at, :utc_datetime_usec
 
     belongs_to :plan, Plan, references: :plan_id

--- a/lib/dash_web/controllers/api/v1/account_controller.ex
+++ b/lib/dash_web/controllers/api/v1/account_controller.ex
@@ -14,7 +14,7 @@ defmodule DashWeb.Api.V1.AccountController do
           {true, active_subscription?, name}
 
         {:ok, %Dash.Capability{is_active: true}} ->
-          {true, true, "standard"}
+          {true, true, "personal"}
 
         {:error, :no_active_plan} ->
           {false, false, nil}

--- a/lib/dash_web/fxa_events.ex
+++ b/lib/dash_web/fxa_events.ex
@@ -90,8 +90,8 @@ defmodule DashWeb.FxaEvents do
     account = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid)
 
     if is_active do
-      with {:error, reason} <- Dash.subscribe_to_standard_plan(account, datetime) do
-        Logger.warning("could not subscribe to standard plan for reason: #{reason}")
+      with {:error, reason} <- Dash.subscribe_to_personal_plan(account, datetime) do
+        Logger.warning("could not subscribe to personal plan for reason: #{reason}")
       end
     else
       with {:error, reason} <- Dash.expire_plan_subscription(account, datetime) do

--- a/priv/repo/migrations/20230628201657_rename_standard_plan_state.exs
+++ b/priv/repo/migrations/20230628201657_rename_standard_plan_state.exs
@@ -1,0 +1,8 @@
+defmodule Dash.Repo.Migrations.RenameStandardPlanState do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TYPE plan_state RENAME VALUE 'standard' TO 'personal'",
+            "ALTER TYPE plan_state RENAME VALUE 'personal' TO 'standard'"
+  end
+end

--- a/priv/repo/migrations/20230629141449_reduce_personal_plan_hub_ccu_limits.exs
+++ b/priv/repo/migrations/20230629141449_reduce_personal_plan_hub_ccu_limits.exs
@@ -1,0 +1,67 @@
+defmodule Dash.Repo.Migrations.ReducePersonalPlanHubCcuLimits do
+  use Ecto.Migration
+
+  alias Dash.Repo
+  import Ecto.Query, only: [from: 2]
+
+  def up,
+    do: put_personal_plan_hub_ccu_limit(20)
+
+  def down,
+    do: put_personal_plan_hub_ccu_limit(25)
+
+  ## Helpers
+
+  @spec hub(pos_integer) :: Ecto.Query.t()
+  defp hub(hub_id) when is_integer(hub_id) and hub_id > 0 do
+    from h in "hubs", where: h.hub_id == ^hub_id
+  end
+
+  @spec personal_hubs :: Ecto.Query.t()
+  defp personal_hubs do
+    from d in "hub_deployments",
+      join: h in "hubs",
+      on: d.hub_id == h.hub_id,
+      join: p in "plans",
+      on: p.account_id == h.account_id,
+      join: t in "plan_transitions",
+      on: t.plan_id == p.plan_id,
+      where:
+        t.plan_transition_id in subquery(
+          from t in "plan_transitions",
+            distinct: t.plan_id,
+            order_by: [desc: t.transitioned_at],
+            select: t.plan_transition_id
+        ),
+      where: t.new_state == "personal",
+      select: %{domain: d.domain, hub_id: h.hub_id}
+  end
+
+  @spec put_personal_plan_hub_ccu_limit(pos_integer) :: :ok
+  defp put_personal_plan_hub_ccu_limit(ccu_limit) do
+    http_client = :hackney
+
+    for %{domain: domain, hub_id: hub_id} <- Repo.all(personal_hubs()) do
+      {:ok, 200, _, _} =
+        http_client.patch(
+          "https://turkeyorch:889/hc_instance",
+          [],
+          Jason.encode!(%{
+            ccu_limit: Integer.to_string(ccu_limit),
+            domain: domain,
+            hub_id: Integer.to_string(hub_id),
+            storage_limit: "1.953125",
+            tier: "p1"
+          }),
+          [:insecure]
+        )
+
+      {1, _} =
+        hub_id
+        |> hub()
+        |> Repo.update_all(set: [ccu_limit: ccu_limit, updated_at: DateTime.utc_now()])
+    end
+
+    :ok
+  end
+end

--- a/test/dash/plan_state_machine_test.exs
+++ b/test/dash/plan_state_machine_test.exs
@@ -63,7 +63,7 @@ defmodule Dash.PlanStateMachineTest do
         is_active: true
       })
 
-      assert {:cont, :standard, nil} === PlanStateMachine.init(account)
+      assert {:cont, :personal, nil} === PlanStateMachine.init(account)
     end
 
     test "when there is an inactive capability (DEPRECATED)", %{account: account} do
@@ -127,7 +127,7 @@ defmodule Dash.PlanStateMachineTest do
       assert 100 > DateTime.diff(DateTime.utc_now(), transition.transitioned_at, :millisecond)
     end
 
-    test "nil -- subscribe_standard ->", %{account: account} do
+    test "nil -- subscribe_personal ->", %{account: account} do
       domain = "region.root.test"
 
       Mox.expect(HttpMock, :post, fn url, json, _headers, opts ->
@@ -135,7 +135,7 @@ defmodule Dash.PlanStateMachineTest do
         [hub] = Hub.hubs_for_account(account)
         assert String.ends_with?(url, "hc_instance")
         assert [hackney: [:insecure], recv_timeout: 15_000] === opts
-        assert "25" === payload["ccu_limit"]
+        assert "20" === payload["ccu_limit"]
         assert false === payload["disable_branding"]
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "us" === payload["region"]
@@ -150,13 +150,13 @@ defmodule Dash.PlanStateMachineTest do
       assert :ok ===
                PlanStateMachine.handle_event(
                  nil,
-                 {:subscribe_standard, DateTime.utc_now()},
+                 {:subscribe_personal, DateTime.utc_now()},
                  account,
                  nil
                )
 
       assert [hub] = Hub.hubs_for_account(account)
-      assert 25 === hub.ccu_limit
+      assert 20 === hub.ccu_limit
       assert :creating === hub.status
       assert 2_000 === hub.storage_limit_mb
       assert :p1 === hub.tier
@@ -166,8 +166,8 @@ defmodule Dash.PlanStateMachineTest do
       assert account.account_id === plan.account_id
 
       assert [transition] = ordered_transitions()
-      assert "subscribe_standard" === transition.event
-      assert :standard === transition.new_state
+      assert "subscribe_personal" === transition.event
+      assert :personal === transition.new_state
       assert plan.plan_id === transition.plan_id
       assert 100 > DateTime.diff(DateTime.utc_now(), transition.transitioned_at, :millisecond)
     end
@@ -208,7 +208,7 @@ defmodule Dash.PlanStateMachineTest do
       assert [_] = ordered_transitions()
     end
 
-    test "starter -- subscribe_standard ->", %{account: account} do
+    test "starter -- subscribe_personal ->", %{account: account} do
       :ok = put_in_state(account, :starter)
       %{hub_id: hub_id} = Repo.insert!(%Hub{account_id: account.account_id})
       Repo.insert!(%HubDeployment{domain: "fake.domain", hub_id: hub_id})
@@ -218,7 +218,7 @@ defmodule Dash.PlanStateMachineTest do
         [hub] = Hub.hubs_for_account(account)
         assert String.ends_with?(url, "hc_instance")
         assert [hackney: [:insecure], recv_timeout: 15_000] === opts
-        assert "25" === payload["ccu_limit"]
+        assert "20" === payload["ccu_limit"]
         assert false === payload["disable_branding"]
         assert hub.deployment.domain === payload["domain"]
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
@@ -234,13 +234,13 @@ defmodule Dash.PlanStateMachineTest do
       assert :ok ===
                PlanStateMachine.handle_event(
                  :starter,
-                 {:subscribe_standard, DateTime.utc_now()},
+                 {:subscribe_personal, DateTime.utc_now()},
                  account,
                  nil
                )
 
       assert [hub] = Hub.hubs_for_account(account)
-      assert 25 === hub.ccu_limit
+      assert 20 === hub.ccu_limit
       assert hub_id === hub.hub_id
       assert :updating === hub.status
       assert 2_000 === hub.storage_limit_mb
@@ -250,8 +250,8 @@ defmodule Dash.PlanStateMachineTest do
       assert account.account_id === plan.account_id
 
       assert [transition, _] = ordered_transitions()
-      assert "subscribe_standard" === transition.event
-      assert :standard === transition.new_state
+      assert "subscribe_personal" === transition.event
+      assert :personal === transition.new_state
       assert plan.plan_id === transition.plan_id
       assert 100 > DateTime.diff(DateTime.utc_now(), transition.transitioned_at, :millisecond)
     end
@@ -270,11 +270,11 @@ defmodule Dash.PlanStateMachineTest do
       assert [_] = ordered_transitions()
     end
 
-    test "standard -- fetch_active_plan ->", %{account: account} do
-      :ok = put_in_state(account, :standard)
+    test "personal -- fetch_active_plan ->", %{account: account} do
+      :ok = put_in_state(account, :personal)
 
       assert {:ok, plan} =
-               PlanStateMachine.handle_event(:standard, :fetch_active_plan, account, nil)
+               PlanStateMachine.handle_event(:personal, :fetch_active_plan, account, nil)
 
       assert %Plan{} = plan
       assert account.account_id === plan.account_id
@@ -283,22 +283,22 @@ defmodule Dash.PlanStateMachineTest do
       assert [_] = ordered_transitions()
     end
 
-    test "standard -- start ->", %{account: account} do
-      :ok = put_in_state(account, :standard)
+    test "personal -- start ->", %{account: account} do
+      :ok = put_in_state(account, :personal)
 
       assert {:error, :already_started} =
-               PlanStateMachine.handle_event(:standard, :start, account, nil)
+               PlanStateMachine.handle_event(:personal, :start, account, nil)
 
       assert [_] = ordered_transitions()
     end
 
-    test "standard -- subscribe_standard ->", %{account: account} do
-      :ok = put_in_state(account, :standard)
+    test "personal -- subscribe_personal ->", %{account: account} do
+      :ok = put_in_state(account, :personal)
 
       assert {:error, :already_started} =
                PlanStateMachine.handle_event(
-                 :standard,
-                 {:subscribe_standard, DateTime.utc_now()},
+                 :personal,
+                 {:subscribe_personal, DateTime.utc_now()},
                  account,
                  nil
                )
@@ -306,8 +306,8 @@ defmodule Dash.PlanStateMachineTest do
       assert [_] = ordered_transitions()
     end
 
-    test "standard -- expire_subscription ->", %{account: account} do
-      :ok = put_in_state(account, :standard)
+    test "personal -- expire_subscription ->", %{account: account} do
+      :ok = put_in_state(account, :personal)
       custom_subdomain = "dummy-subdomain"
 
       %{hub_id: hub_id} =
@@ -335,7 +335,7 @@ defmodule Dash.PlanStateMachineTest do
 
       assert :ok ===
                PlanStateMachine.handle_event(
-                 :standard,
+                 :personal,
                  {:expire_subscription, DateTime.utc_now()},
                  account,
                  nil
@@ -364,9 +364,9 @@ defmodule Dash.PlanStateMachineTest do
   defp ordered_transitions,
     do: Repo.all(from t in PlanStateMachine.PlanTransition, order_by: [desc: t.transitioned_at])
 
-  @spec put_in_state(Account.t(), :starter | :standard | :stopped) :: :ok
+  @spec put_in_state(Account.t(), :starter | :personal | :stopped) :: :ok
   defp put_in_state(%Account{} = account, state)
-       when state in [:starter, :standard, :stopped] do
+       when state in [:starter, :personal, :stopped] do
     %{plan_id: plan_id} = Repo.insert!(%Plan{account_id: account.account_id})
 
     Repo.insert!(%PlanStateMachine.PlanTransition{

--- a/test/dash_test.exs
+++ b/test/dash_test.exs
@@ -211,7 +211,7 @@ defmodule DashTest do
       expired_at: expired_at
     } do
       expect_orch_post()
-      :ok = Dash.subscribe_to_standard_plan(account, DateTime.add(expired_at, -1, :second))
+      :ok = Dash.subscribe_to_personal_plan(account, DateTime.add(expired_at, -1, :second))
       custom_subdomain = "dummy-subdomain"
 
       %{hub_id: hub_id} =
@@ -266,7 +266,7 @@ defmodule DashTest do
       %{hub_id: hub_id} =
         Repo.insert!(%Hub{
           account_id: account.account_id,
-          ccu_limit: 25,
+          ccu_limit: 20,
           status: :creating,
           storage_limit_mb: 2_000,
           subdomain: custom_subdomain,
@@ -309,7 +309,7 @@ defmodule DashTest do
     test "with expired_at earlier than the last state transition, when the account has an active subscription plan",
          %{account: account, expired_at: expired_at} do
       expect_orch_post()
-      :ok = Dash.subscribe_to_standard_plan(account, DateTime.add(expired_at, 1, :second))
+      :ok = Dash.subscribe_to_personal_plan(account, DateTime.add(expired_at, 1, :second))
       custom_subdomain = "dummy-subdomain"
 
       Hub.hubs_for_account(account)
@@ -349,11 +349,11 @@ defmodule DashTest do
       assert {:ok, %Plan{name: "starter", subscription?: false}} = Dash.fetch_active_plan(account)
     end
 
-    test "when the account has an active standard plan", %{account: account} do
+    test "when the account has an active personal plan", %{account: account} do
       expect_orch_post()
-      :ok = Dash.subscribe_to_standard_plan(account, DateTime.utc_now())
+      :ok = Dash.subscribe_to_personal_plan(account, DateTime.utc_now())
 
-      assert {:ok, %Plan{name: "standard", subscription?: true}} = Dash.fetch_active_plan(account)
+      assert {:ok, %Plan{name: "personal", subscription?: true}} = Dash.fetch_active_plan(account)
     end
 
     test "when the account has an active subscription plan (DEPRECATED capability)", %{
@@ -439,7 +439,7 @@ defmodule DashTest do
 
     test "when the account has an active subscription plan", %{account: account} do
       expect_orch_post()
-      :ok = Dash.subscribe_to_standard_plan(account, DateTime.utc_now())
+      :ok = Dash.subscribe_to_personal_plan(account, DateTime.utc_now())
 
       assert {:error, :already_started} === Dash.start_plan(account)
     end
@@ -490,14 +490,14 @@ defmodule DashTest do
     test "when the account has a stopped plan"
   end
 
-  describe "subscribe_to_standard_plan/2" do
+  describe "subscribe_to_personal_plan/2" do
     setup do
       %{account: create_account(), subscribed_at: ~U[1970-01-01 00:00:00.877000Z]}
     end
 
     test "when the account cannot be found", %{subscribed_at: subscribed_at} do
       assert {:error, :account_not_found} ===
-               Dash.subscribe_to_standard_plan(%Account{account_id: 1}, subscribed_at)
+               Dash.subscribe_to_personal_plan(%Account{account_id: 1}, subscribed_at)
     end
 
     test "when the account has an active subscription plan", %{
@@ -505,10 +505,10 @@ defmodule DashTest do
       subscribed_at: subscribed_at
     } do
       expect_orch_post()
-      :ok = Dash.subscribe_to_standard_plan(account, subscribed_at)
+      :ok = Dash.subscribe_to_personal_plan(account, subscribed_at)
 
       assert {:error, :already_started} ===
-               Dash.subscribe_to_standard_plan(account, subscribed_at)
+               Dash.subscribe_to_personal_plan(account, subscribed_at)
     end
 
     test "when the account has an active subscription plan (DEPRECATED capability)", %{
@@ -522,7 +522,7 @@ defmodule DashTest do
       })
 
       assert {:error, :already_started} ===
-               Dash.subscribe_to_standard_plan(account, subscribed_at)
+               Dash.subscribe_to_personal_plan(account, subscribed_at)
     end
 
     test "when the account has no plan", %{
@@ -536,7 +536,7 @@ defmodule DashTest do
         [hub] = Hub.hubs_for_account(account)
         assert String.ends_with?(url, "hc_instance")
         assert [hackney: [:insecure], recv_timeout: 15_000] === opts
-        assert "25" === payload["ccu_limit"]
+        assert "20" === payload["ccu_limit"]
         assert false === payload["disable_branding"]
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
         assert "us" === payload["region"]
@@ -548,10 +548,10 @@ defmodule DashTest do
         {:ok, %HTTPoison.Response{body: Jason.encode!(%{domain: domain}), status_code: 200}}
       end)
 
-      assert :ok === Dash.subscribe_to_standard_plan(account, subscribed_at)
+      assert :ok === Dash.subscribe_to_personal_plan(account, subscribed_at)
       assert {:ok, %{subscription?: true}} = Dash.fetch_active_plan(account)
       assert [hub] = Hub.hubs_for_account(account)
-      assert 25 === hub.ccu_limit
+      assert 20 === hub.ccu_limit
       assert :creating === hub.status
       assert 2_000 === hub.storage_limit_mb
       assert :p1 === hub.tier
@@ -576,7 +576,7 @@ defmodule DashTest do
         [hub] = Hub.hubs_for_account(account)
         assert String.ends_with?(url, "hc_instance")
         assert [hackney: [:insecure], recv_timeout: 15_000] === opts
-        assert "25" === payload["ccu_limit"]
+        assert "20" === payload["ccu_limit"]
         assert false === payload["disable_branding"]
         assert hub.deployment.domain === payload["domain"]
         assert Integer.to_string(hub.hub_id) === payload["hub_id"]
@@ -589,12 +589,12 @@ defmodule DashTest do
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
-      assert :ok === Dash.subscribe_to_standard_plan(account, after_start)
+      assert :ok === Dash.subscribe_to_personal_plan(account, after_start)
       {:ok, plan} = Dash.fetch_active_plan(account)
       assert plan_id === plan.plan_id
       assert plan.subscription?
       assert [hub] = Hub.hubs_for_account(account)
-      assert 25 === hub.ccu_limit
+      assert 20 === hub.ccu_limit
       assert hub_id === hub.hub_id
       assert :updating === hub.status
       assert 2_000 === hub.storage_limit_mb

--- a/test/dash_web/controllers/api/v1/account_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/account_controller_test.exs
@@ -81,7 +81,7 @@ defmodule DashWeb.Api.V1.AccountControllerTest do
       assert "starter" === payload["planName"]
     end
 
-    test "when the account has an active standard plan", %{conn: conn} do
+    test "when the account has an active personal plan", %{conn: conn} do
       stub_http_post_200()
 
       assert payload =
@@ -91,7 +91,7 @@ defmodule DashWeb.Api.V1.AccountControllerTest do
                |> json_response(200)
 
       assert true === payload["hasPlan"]
-      assert "standard" === payload["planName"]
+      assert "personal" === payload["planName"]
     end
   end
 end

--- a/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
+++ b/test/dash_web/controllers/api/v1/fxa_events_controller_test.exs
@@ -218,7 +218,7 @@ defmodule DashWeb.Api.V1.FxaEventsControllerTest do
       fxa_uid = "dummy-uid"
       the_past = ~U[1970-01-01 00:00:00.000000Z]
       account = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid, "dummy@test.com")
-      :ok = Dash.subscribe_to_standard_plan(account, the_past)
+      :ok = Dash.subscribe_to_personal_plan(account, the_past)
 
       token =
         [


### PR DESCRIPTION
# 🚨 Release Notes 🚨 
- [ ] Deploy the client changes first

Why
---
We are replacing the _Early Access_ plan with _Personal_.  Personal plans have a 20 CCU limit, a reduction from the 25 CCU limit of early access plans.

What
----
* Replace `standard` with `personal`
* Reduce CCU limit for new personal plans
* Reduce personal plan hub CCU limits in database
* Send Orch request to reduce personal plan hub CCU limits