### PR TITLE
Increase state machine transaction timeout

### DIFF
--- a/lib/dash/plan_state_machine.ex
+++ b/lib/dash/plan_state_machine.ex
@@ -26,7 +26,12 @@ defmodule Dash.PlanStateMachine do
   @spec handle_event(:active?, Account.t()) :: {:ok, boolean} | {:error, :account_not_found}
   @spec handle_event(:start, Account.t()) :: :ok | {:error, :account_not_found | :already_started}
   def handle_event(event, %Account{} = account) do
-    {:ok, result} = Repo.transaction(fn -> Mimzy.handle_event(account, event, __MODULE__) end)
+    {:ok, result} =
+      Repo.transaction(
+        fn -> Mimzy.handle_event(account, event, __MODULE__) end,
+        timeout: 30_000
+      )
+
     result
   end
 


### PR DESCRIPTION
Why
---
We are seeing this in the logs:

> disconnected: ** (DBConnection.ConnectionError) client #PID<...> timed out because it queued and checked out the connection for longer than 15000ms

Transactions are timing out because they have to wait for Orch to respond.

What
----
Set the transaction timeout to the sum of the Orch timeout (15 seconds) and the default timeout (15 seconds): 30 seconds.
