### PR TITLE
Terminate transition if database row is locked

### DIFF
--- a/lib/dash/plan_state_machine.ex
+++ b/lib/dash/plan_state_machine.ex
@@ -23,8 +23,16 @@ defmodule Dash.PlanStateMachine do
 
   Returns `{:error, :account_not_found}` if the account cannot be located.
   """
-  @spec handle_event(:active?, Account.t()) :: {:ok, boolean} | {:error, :account_not_found}
-  @spec handle_event(:start, Account.t()) :: :ok | {:error, :account_not_found | :already_started}
+  @spec handle_event(:fetch_active_plan, Account.t()) ::
+          {:ok, Plan.t()} | {:error, :account_not_found | :no_active_plan}
+  @spec handle_event(:start, Account.t()) ::
+          :ok | {:error, :account_not_found | :already_started}
+  @spec handle_event({:expire_subscription, DateTime.t()}, Account.t()) ::
+          :ok | {:error, :account_not_found | :no_subscription | :superseded}
+  @spec handle_event({:subscribe_personal, DateTime.t()}, Account.t()) ::
+          :ok | {:error, :account_not_found | :already_started | :superseded}
+  @spec handle_event({:subscribe_professional, DateTime.t()}, Account.t()) ::
+          :ok | {:error, :account_not_found | :already_started | :superseded}
   def handle_event(event, %Account{} = account) do
     {:ok, result} =
       Repo.transaction(


### PR DESCRIPTION
Why
---
The FxA broker is re-sending events before the webhook has a chance to respond.  This is leading to duplicate requests running in parallel and a long queue of row-level lock requests.