### PR TITLE
fix: Remove "early access" copy

### DIFF
--- a/client/components/modules/plans/plan-cards/ProfessionalPlanCard.tsx
+++ b/client/components/modules/plans/plan-cards/ProfessionalPlanCard.tsx
@@ -29,7 +29,7 @@ const ProfessionalPlanCard = ({
   return (
     <BasePlanCard
       plan={PlansE.PROFESSIONAL}
-      title="Professional (Early Access)"
+      title="Professional"
       color="rainbow"
       price={
         <Price

--- a/marketing/components/shared/Subscribe/ProfessionalPlanCard/ProfessionalPlanCard.tsx
+++ b/marketing/components/shared/Subscribe/ProfessionalPlanCard/ProfessionalPlanCard.tsx
@@ -28,7 +28,7 @@ const ProfessionalPlanCard = ({
 
   return (
     <BasePlanCard
-      title="Professional (Early Access)"
+      title="Professional"
       color="rainbow"
       price={
         <Price


### PR DESCRIPTION
As requested, updated copy to remove the below. 
<img width="1704" alt="Screen_Shot_2023-08-08_at_2 54 08_PM" src="https://github.com/mozilla/turkey-portal/assets/42850541/1c3c8180-7389-489f-8f9b-92f20ff2ce63">
