### PR TITLE
Fix account deletion

### DIFF
--- a/lib/dash.ex
+++ b/lib/dash.ex
@@ -275,7 +275,7 @@ defmodule Dash do
 
   @spec fxa_uid_to_deleted_list(String.t()) :: :ok
   def fxa_uid_to_deleted_list(fxa_uid) when is_binary(fxa_uid) do
-    Dash.Repo.insert(%Dash.DeletedFxaAccount{fxa_uid: fxa_uid})
+    Dash.Repo.insert!(%Dash.DeletedFxaAccount{fxa_uid: fxa_uid}, on_conflict: :nothing)
     :ok
   end
 


### PR DESCRIPTION
Why
---
The FxA broker doesn’t wait for a response before re-trying an event.  This means event-handling needs to be idempotent.  Account deletion is not currently idempotent.  This is leading to needless retries and a noisy log.

What
----
* Make `Dash.fxa_uid_to_deleted_list/1` insert a deletion record only if one doesn’t already exist