### PR TITLE
Unblock FxA broker on email change

### DIFF
--- a/lib/dash.ex
+++ b/lib/dash.ex
@@ -207,7 +207,6 @@ defmodule Dash do
   def change_email(nil, _email), do: :ok
 
   def change_email(%Dash.Account{email: nil} = account, email) when is_binary(email) do
-    [] = Dash.Hub.hubs_for_account(account)
     update_email(account, email)
   end
 

--- a/test/dash_test.exs
+++ b/test/dash_test.exs
@@ -29,16 +29,6 @@ defmodule DashTest do
       assert :ok === result
     end
 
-    test "should raise, account has no previously set email, has hubs" do
-      expect_orch_post()
-
-      fxa_uid = "no_email"
-      account_without_email = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid)
-      Dash.Hub.create_default_hub(account_without_email, @old_email)
-
-      assert_raise MatchError, fn -> Dash.change_email(account_without_email, @new_email) end
-    end
-
     test "should return :ok, account has previously set email and has no hubs" do
       fxa_uid = "with_email"
       account_with_email = Dash.Account.find_or_create_account_for_fxa_uid(fxa_uid, @old_email)


### PR DESCRIPTION
Why
---
There is a validation on email change that an account with a hub has an
email address stored.  However, some accounts with hubs exist without a
stored email address.  If the validation is necessary it should be
enforced when the record is persisted, not just accessed.  This failing
validation is blocking the FxA broker, which continues to retry the
event.

What
----
* Since email updates in Reticulum are broken anyway, remove the
  aforementioned validation