### PR TITLE
adding spoke, ce, and fixing mobile docs

### DIFF
--- a/marketing/components/navigation/MainNav/MainNav.tsx
+++ b/marketing/components/navigation/MainNav/MainNav.tsx
@@ -75,6 +75,7 @@ const MainNav = ({
                 <a
                   href="https://github.com/mozilla/hubs-cloud/tree/master/community-edition"
                   target="_blank"
+                  rel="noreferrer"
                   className={styles.main_nav_link}
                 >
                   Community Edition
@@ -83,6 +84,7 @@ const MainNav = ({
                 <a
                   href="/E4e8oLx/hubs-demo-promenade"
                   target="_blank"
+                  rel="noreferrer"
                   className={styles.main_nav_link}
                 >
                   Explore Hubs

--- a/marketing/components/navigation/MobileSideNav/MobileSideNav.tsx
+++ b/marketing/components/navigation/MobileSideNav/MobileSideNav.tsx
@@ -81,10 +81,11 @@ const MobileSideNav = ({
               </a>
             </li>
             <li>
-              <a 
-                className={styles.nav_link} 
+              <a
+                className={styles.nav_link}
                 href="https://github.com/mozilla/hubs-cloud/tree/master/community-edition"
                 target="_blank"
+                rel="noreferrer"
               >
                 Community Edition
               </a>
@@ -94,6 +95,7 @@ const MobileSideNav = ({
                 className={styles.nav_link}
                 href="/E4e8oLx/hubs-demo-promenade"
                 target="_blank"
+                rel="noreferrer"
               >
                 Explore Hubs
               </a>


### PR DESCRIPTION
Howdy @nickgrato! I'm hoping to add spoke and community edition to the nav bar of the marketing page and fix the Docs link (currently it still points to Hubs Cloud) on mobile. For community edition, I would like it to open in a new tab. For spoke, it should open in the same tab.